### PR TITLE
[wip] working with pipes; closes #19

### DIFF
--- a/serverscommands/instancecommands/common.go
+++ b/serverscommands/instancecommands/common.go
@@ -33,11 +33,16 @@ func idOrName(c *cli.Context, client *gophercloud.ServiceClient) string {
 var idAndNameFlags = []cli.Flag{
 	cli.StringFlag{
 		Name:  "id",
-		Usage: "[optional; required if 'name' is not provided] The ID of the server to update",
+		Usage: "[optional; required if 'name' is not provided] The ID of the server to update.",
 	},
 	cli.StringFlag{
 		Name:  "name",
-		Usage: "[optional; required if 'id' is not provided] The name of the server to update",
+		Usage: "[optional; required if 'id' is not provided] The name of the server to updat.e",
+	},
+	cli.StringFlag{
+		Name:  "sep",
+		Usage: "[optional] The separator to use for splitting multiple IDs or names.",
+		Value: ",",
 	},
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -37,6 +38,10 @@ func commonFlags() []cli.Flag {
 		cli.BoolFlag{
 			Name:  "table",
 			Usage: "Return output in tabular format. This is the default output format.",
+		},
+		cli.BoolFlag{
+			Name:  "noborder",
+			Usage: "Don't print a border when output format is tabular or csv",
 		},
 	}
 }
@@ -91,4 +96,17 @@ func CheckKVFlag(c *cli.Context, flagName string) map[string]string {
 		kv[temp[0]] = temp[1]
 	}
 	return kv
+}
+
+// ReadStdin will read from stdin and return the data as a slice of bytes if
+// it exists.
+func ReadStdin(c *cli.Context) []byte {
+	fileInfo, _ := os.Stdin.Stat()
+	if (fileInfo.Mode() & os.ModeCharDevice) == 0 {
+		// from pipe
+		bytes, _ := ioutil.ReadAll(os.Stdin)
+		return bytes
+	}
+	// from terminal
+	return nil
 }


### PR DESCRIPTION
This PR addresses #19 .

It adds a few items:
1. A `sep` flag that's grouped with `id` and `name` flags that allows users to specify a separator for the string of input items. Currently it defaults to a comma (",").
2. A `fields` flag that lets users specify which fields they want returned in the output.
3. A `noborder` flag that lets users return a table without a border.
4. A `ReadStdin` function that will read from stdin if anything exists there.

Currently, the only use-case is piping the result of listing servers into the delete servers command:
`rack servers instance list --name rack --fields id --noborder | tail -n+3 | rack servers instance delete --sep " "`

If we like this, I'll refactor some of the code to make it easier for other commands to use. 