### PR TITLE
Plain tables

### DIFF
--- a/serverscommands/flavorcommands/get.go
+++ b/serverscommands/flavorcommands/get.go
@@ -5,11 +5,9 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
-	"github.com/fatih/structs"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
-	"github.com/olekukonko/tablewriter"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/flavors"
 )
 
@@ -41,13 +39,5 @@ func commandGet(c *cli.Context) {
 }
 
 func tableGet(c *cli.Context, i interface{}) {
-	m := structs.Map(i)
-	t := tablewriter.NewWriter(c.App.Writer)
-	t.SetAlignment(tablewriter.ALIGN_LEFT)
-	t.SetHeader([]string{"property", "value"})
-	keys := []string{"ID", "Name", "Disk", "RAM", "RxTxFactor", "Swap", "VCPUs"}
-	for _, key := range keys {
-		t.Append([]string{key, fmt.Sprint(m[key])})
-	}
-	t.Render()
+	util.MetaDataPrint(c, i, []string{"ID", "Name", "Disk", "RAM", "RxTxFactor", "Swap", "VCPUs"})
 }

--- a/serverscommands/flavorcommands/get.go
+++ b/serverscommands/flavorcommands/get.go
@@ -39,5 +39,6 @@ func commandGet(c *cli.Context) {
 }
 
 func tableGet(c *cli.Context, i interface{}) {
-	util.MetaDataPrint(c, i, []string{"ID", "Name", "Disk", "RAM", "RxTxFactor", "Swap", "VCPUs"})
+	keys := []string{"ID", "Name", "Disk", "RAM", "RxTxFactor", "Swap", "VCPUs"}
+	util.MetaDataPrint(c, i, keys)
 }

--- a/serverscommands/flavorcommands/get.go
+++ b/serverscommands/flavorcommands/get.go
@@ -40,5 +40,5 @@ func commandGet(c *cli.Context) {
 
 func tableGet(c *cli.Context, i interface{}) {
 	keys := []string{"ID", "Name", "Disk", "RAM", "RxTxFactor", "Swap", "VCPUs"}
-	util.MetaDataPrint(c, i, keys)
+	util.MetaDataTable(c, i, keys)
 }

--- a/serverscommands/flavorcommands/list.go
+++ b/serverscommands/flavorcommands/list.go
@@ -3,13 +3,14 @@ package flavorcommands
 import (
 	"fmt"
 	"os"
+	"strings"
+	"text/tabwriter"
 
 	"github.com/codegangsta/cli"
 	"github.com/fatih/structs"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
-	"github.com/olekukonko/tablewriter"
 	osFlavors "github.com/rackspace/gophercloud/openstack/compute/v2/flavors"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/flavors"
 )
@@ -75,17 +76,19 @@ func tableList(c *cli.Context, i interface{}) {
 		fmt.Fprintf(c.App.Writer, "Could not type assert interface\n%+v\nto []osFlavors.Flavor\n", i)
 		os.Exit(1)
 	}
-	t := tablewriter.NewWriter(c.App.Writer)
-	t.SetAlignment(tablewriter.ALIGN_LEFT)
 	keys := []string{"ID", "Name", "RAM", "Disk", "Swap", "VCPUs", "RxTxFactor"}
-	t.SetHeader(keys)
+
+	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 0, '\t', 0)
+	// Write the header
+	fmt.Fprintln(w, strings.Join(keys, "\t"))
+
 	for _, flavor := range flavors {
 		m := structs.Map(flavor)
 		f := []string{}
 		for _, key := range keys {
 			f = append(f, fmt.Sprint(m[key]))
 		}
-		t.Append(f)
+		fmt.Fprintln(w, strings.Join(f, "\t"))
 	}
-	t.Render()
+	w.Flush()
 }

--- a/serverscommands/flavorcommands/list.go
+++ b/serverscommands/flavorcommands/list.go
@@ -3,8 +3,6 @@ package flavorcommands
 import (
 	"fmt"
 	"os"
-	"strings"
-	"text/tabwriter"
 
 	"github.com/codegangsta/cli"
 	"github.com/fatih/structs"
@@ -78,17 +76,13 @@ func tableList(c *cli.Context, i interface{}) {
 	}
 	keys := []string{"ID", "Name", "RAM", "Disk", "Swap", "VCPUs", "RxTxFactor"}
 
-	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 0, '\t', 0)
-	// Write the header
-	fmt.Fprintln(w, strings.Join(keys, "\t"))
-
+	// Prebuild the maps
+	maps := make([]map[string]interface{}, len(flavors))
 	for _, flavor := range flavors {
 		m := structs.Map(flavor)
-		f := []string{}
-		for _, key := range keys {
-			f = append(f, fmt.Sprint(m[key]))
-		}
-		fmt.Fprintln(w, strings.Join(f, "\t"))
+		maps = append(maps, m)
 	}
-	w.Flush()
+
+	util.SimpleTable(c, keys, maps)
+
 }

--- a/serverscommands/flavorcommands/list.go
+++ b/serverscommands/flavorcommands/list.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
-	"github.com/fatih/structs"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
@@ -76,19 +75,12 @@ func tableList(c *cli.Context, i interface{}) {
 	}
 	keys := []string{"ID", "Name", "RAM", "Disk", "Swap", "VCPUs", "RxTxFactor"}
 
-	// Prebuild the maps
-	maps := make([]map[string]interface{}, len(flavors))
-	for _, flavor := range flavors {
-		m := structs.Map(flavor)
-		maps = append(maps, m)
-	}
-
+	// Allocate a generic []interface{} of the right size
 	is := make([]interface{}, len(flavors))
 	for i, d := range flavors {
 		is[i] = d
 	}
 
-	maps = util.BuildMaps(is)
-	util.SimpleTable(c, keys, maps)
+	util.SimpleTable(c, keys, is)
 
 }

--- a/serverscommands/flavorcommands/list.go
+++ b/serverscommands/flavorcommands/list.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
+	"github.com/fatih/structs"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
@@ -75,12 +76,11 @@ func tableList(c *cli.Context, i interface{}) {
 	}
 	keys := []string{"ID", "Name", "RAM", "Disk", "Swap", "VCPUs", "RxTxFactor"}
 
-	// Allocate a generic []interface{} of the right size
-	is := make([]interface{}, len(flavors))
-	for i, d := range flavors {
-		is[i] = d
+	var maps []map[string]interface{}
+	for _, flavor := range flavors {
+		maps = append(maps, structs.Map(flavor))
 	}
 
-	util.SimpleListing(c, is, keys)
+	util.SimpleMapsTable(c, maps, keys)
 
 }

--- a/serverscommands/flavorcommands/list.go
+++ b/serverscommands/flavorcommands/list.go
@@ -81,6 +81,6 @@ func tableList(c *cli.Context, i interface{}) {
 		is[i] = d
 	}
 
-	util.SimpleTable(c, keys, is)
+	util.SimpleListing(c, keys, is)
 
 }

--- a/serverscommands/flavorcommands/list.go
+++ b/serverscommands/flavorcommands/list.go
@@ -83,6 +83,12 @@ func tableList(c *cli.Context, i interface{}) {
 		maps = append(maps, m)
 	}
 
+	is := make([]interface{}, len(flavors))
+	for i, d := range flavors {
+		is[i] = d
+	}
+
+	maps = util.BuildMaps(is)
 	util.SimpleTable(c, keys, maps)
 
 }

--- a/serverscommands/flavorcommands/list.go
+++ b/serverscommands/flavorcommands/list.go
@@ -81,6 +81,6 @@ func tableList(c *cli.Context, i interface{}) {
 		maps = append(maps, structs.Map(flavor))
 	}
 
-	util.SimpleMapsTable(c, maps, keys)
+	util.Table(c, maps, keys)
 
 }

--- a/serverscommands/flavorcommands/list.go
+++ b/serverscommands/flavorcommands/list.go
@@ -81,6 +81,6 @@ func tableList(c *cli.Context, i interface{}) {
 		is[i] = d
 	}
 
-	util.SimpleListing(c, keys, is)
+	util.SimpleListing(c, is, keys)
 
 }

--- a/serverscommands/flavorcommands/list.go
+++ b/serverscommands/flavorcommands/list.go
@@ -81,6 +81,6 @@ func tableList(c *cli.Context, i interface{}) {
 		maps = append(maps, structs.Map(flavor))
 	}
 
-	util.Table(c, maps, keys)
+	util.ListTable(c, maps, keys)
 
 }

--- a/serverscommands/imagecommands/get.go
+++ b/serverscommands/imagecommands/get.go
@@ -40,5 +40,5 @@ func commandGet(c *cli.Context) {
 
 func tableGet(c *cli.Context, i interface{}) {
 	keys := []string{"ID", "Name", "Status", "Progress", "MinDisk", "MinRAM", "Created", "Updated"}
-	util.MetaDataPrint(c, i, keys)
+	util.MetaDataTable(c, i, keys)
 }

--- a/serverscommands/imagecommands/get.go
+++ b/serverscommands/imagecommands/get.go
@@ -5,11 +5,9 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
-	"github.com/fatih/structs"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
-	"github.com/olekukonko/tablewriter"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/images"
 )
 
@@ -41,13 +39,6 @@ func commandGet(c *cli.Context) {
 }
 
 func tableGet(c *cli.Context, i interface{}) {
-	m := structs.Map(i)
-	t := tablewriter.NewWriter(c.App.Writer)
-	t.SetAlignment(tablewriter.ALIGN_LEFT)
-	t.SetHeader([]string{"property", "value"})
 	keys := []string{"ID", "Name", "Status", "Progress", "MinDisk", "MinRAM", "Created", "Updated"}
-	for _, key := range keys {
-		t.Append([]string{key, fmt.Sprint(m[key])})
-	}
-	t.Render()
+	util.MetaDataPrint(c, i, keys)
 }

--- a/serverscommands/imagecommands/list.go
+++ b/serverscommands/imagecommands/list.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
+	"github.com/fatih/structs"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
@@ -75,11 +76,11 @@ func tableList(c *cli.Context, i interface{}) {
 
 	keys := []string{"ID", "Name", "Status", "MinDisk", "MinRAM"}
 
-	many := make([]interface{}, len(images))
-	for i, d := range images {
-		many[i] = d
+	var maps []map[string]interface{}
+	for _, image := range images {
+		maps = append(maps, structs.Map(image))
 	}
 
-	util.SimpleListing(c, many, keys)
+	util.SimpleMapsTable(c, maps, keys)
 
 }

--- a/serverscommands/imagecommands/list.go
+++ b/serverscommands/imagecommands/list.go
@@ -81,6 +81,6 @@ func tableList(c *cli.Context, i interface{}) {
 		maps = append(maps, structs.Map(image))
 	}
 
-	util.SimpleMapsTable(c, maps, keys)
+	util.Table(c, maps, keys)
 
 }

--- a/serverscommands/imagecommands/list.go
+++ b/serverscommands/imagecommands/list.go
@@ -81,6 +81,6 @@ func tableList(c *cli.Context, i interface{}) {
 		maps = append(maps, structs.Map(image))
 	}
 
-	util.Table(c, maps, keys)
+	util.ListTable(c, maps, keys)
 
 }

--- a/serverscommands/imagecommands/list.go
+++ b/serverscommands/imagecommands/list.go
@@ -5,11 +5,9 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
-	"github.com/fatih/structs"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
-	"github.com/olekukonko/tablewriter"
 	osImages "github.com/rackspace/gophercloud/openstack/compute/v2/images"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/images"
 )
@@ -74,18 +72,14 @@ func tableList(c *cli.Context, i interface{}) {
 		fmt.Fprintf(c.App.Writer, "Could not type assert interface\n%+v\nto []osImages.Image\n", i)
 		os.Exit(1)
 	}
-	t := tablewriter.NewWriter(c.App.Writer)
-	t.SetAlignment(tablewriter.ALIGN_LEFT)
-	t.SetColWidth(100)
+
 	keys := []string{"ID", "Name", "Status", "MinDisk", "MinRAM"}
-	t.SetHeader(keys)
-	for _, image := range images {
-		m := structs.Map(image)
-		f := []string{}
-		for _, key := range keys {
-			f = append(f, fmt.Sprint(m[key]))
-		}
-		t.Append(f)
+
+	many := make([]interface{}, len(images))
+	for i, d := range images {
+		many[i] = d
 	}
-	t.Render()
+
+	util.SimpleListing(c, many, keys)
+
 }

--- a/serverscommands/instancecommands/common.go
+++ b/serverscommands/instancecommands/common.go
@@ -42,3 +42,37 @@ var idAndNameFlags = []cli.Flag{
 }
 
 var idOrNameUsage = "[--id <serverID> | --name <serverName>]"
+
+func mungeServerMap(m map[string]interface{}) {
+	m["Public IPv4"] = m["AccessIPv4"]
+	m["Public IPv6"] = m["AccessIPv6"]
+
+	// Private IPv4 case
+	// Nested m["Addresses"]["private"][0]
+	addrs, ok := m["Addresses"].(map[string]interface{})
+	if ok {
+		ips, ok := addrs["private"].([]interface{})
+		if ok || len(ips) > 0 {
+			priv, ok := ips[0].(map[string]interface{})
+			if ok {
+				m["Private IPv4"] = priv["addr"]
+			}
+		}
+	}
+	if !ok { // if any were not ok, set the field to blank
+		m["Private IPv4"] = ""
+	}
+
+	flavor, ok := m["Flavor"].(map[string]interface{})
+	if ok {
+		m["Flavor"] = flavor["id"]
+	} else {
+		m["Flavor"] = ""
+	}
+	image, ok := m["Image"].(map[string]interface{})
+	if ok {
+		m["Image"] = image["id"]
+	} else {
+		m["Image"] = ""
+	}
+}

--- a/serverscommands/instancecommands/create.go
+++ b/serverscommands/instancecommands/create.go
@@ -129,5 +129,6 @@ func commandCreate(c *cli.Context) {
 }
 
 func tableCreate(c *cli.Context, i interface{}) {
-	util.MetaDataPrint(c, i, []string{"ID", "AdminPass"})
+	keys := []string{"ID", "AdminPass"}
+	util.MetaDataPrint(c, i, keys)
 }

--- a/serverscommands/instancecommands/create.go
+++ b/serverscommands/instancecommands/create.go
@@ -130,5 +130,5 @@ func commandCreate(c *cli.Context) {
 
 func tableCreate(c *cli.Context, i interface{}) {
 	keys := []string{"ID", "AdminPass"}
-	util.MetaDataPrint(c, i, keys)
+	util.MetaDataTable(c, i, keys)
 }

--- a/serverscommands/instancecommands/create.go
+++ b/serverscommands/instancecommands/create.go
@@ -7,11 +7,9 @@ import (
 	"strings"
 
 	"github.com/codegangsta/cli"
-	"github.com/fatih/structs"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
-	"github.com/olekukonko/tablewriter"
 	osServers "github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
 )
@@ -131,13 +129,5 @@ func commandCreate(c *cli.Context) {
 }
 
 func tableCreate(c *cli.Context, i interface{}) {
-	m := structs.Map(i)
-	t := tablewriter.NewWriter(c.App.Writer)
-	t.SetAlignment(tablewriter.ALIGN_LEFT)
-	t.SetHeader([]string{"property", "value"})
-	keys := []string{"ID", "AdminPass"}
-	for _, key := range keys {
-		t.Append([]string{key, fmt.Sprint(m[key])})
-	}
-	t.Render()
+	util.MetaDataPrint(c, i, []string{"ID", "AdminPass"})
 }

--- a/serverscommands/instancecommands/get.go
+++ b/serverscommands/instancecommands/get.go
@@ -47,37 +47,7 @@ func tableGet(c *cli.Context, i interface{}) {
 	t.SetHeader([]string{"property", "value"})
 	keys := []string{"ID", "Name", "Status", "Created", "Updated", "Image", "Flavor", "Public IPv4", "Public IPv6", "Private IPv4", "KeyName"}
 
-	m["Public IPv4"] = m["AccessIPv4"]
-	m["Public IPv6"] = m["AccessIPv6"]
-
-	// Private IPv4 case
-	// Nested m["Addresses"]["private"][0]
-	addrs, ok := m["Addresses"].(map[string]interface{})
-	if ok {
-		ips, ok := addrs["private"].([]interface{})
-		if ok || len(ips) > 0 {
-			priv, ok := ips[0].(map[string]interface{})
-			if ok {
-				m["Private IPv4"] = priv["addr"]
-			}
-		}
-	}
-	if !ok { // if any were not ok, set the field to blank
-		m["Private IPv4"] = ""
-	}
-
-	flavor, ok := m["Flavor"].(map[string]interface{})
-	if ok {
-		m["Flavor"] = flavor["id"]
-	} else {
-		m["Flavor"] = ""
-	}
-	image, ok := m["Image"].(map[string]interface{})
-	if ok {
-		m["Image"] = image["id"]
-	} else {
-		m["Image"] = ""
-	}
+	mungeServerMap(m)
 
 	for _, key := range keys {
 		t.Append([]string{key, fmt.Sprint(m[key])})

--- a/serverscommands/instancecommands/get.go
+++ b/serverscommands/instancecommands/get.go
@@ -46,51 +46,41 @@ func tableGet(c *cli.Context, i interface{}) {
 	t.SetAlignment(tablewriter.ALIGN_LEFT)
 	t.SetHeader([]string{"property", "value"})
 	keys := []string{"ID", "Name", "Status", "Created", "Updated", "Image", "Flavor", "Public IPv4", "Public IPv6", "Private IPv4", "KeyName"}
+
+	m["Public IPv4"] = m["AccessIPv4"]
+	m["Public IPv6"] = m["AccessIPv6"]
+
+	// Private IPv4 case
+	// Nested m["Addresses"]["private"][0]
+	addrs, ok := m["Addresses"].(map[string]interface{})
+	if ok {
+		ips, ok := addrs["private"].([]interface{})
+		if ok || len(ips) > 0 {
+			priv, ok := ips[0].(map[string]interface{})
+			if ok {
+				m["Private IPv4"] = priv["addr"]
+			}
+		}
+	}
+	if !ok { // if any were not ok, set the field to blank
+		m["Private IPv4"] = ""
+	}
+
+	flavor, ok := m["Flavor"].(map[string]interface{})
+	if ok {
+		m["Flavor"] = flavor["id"]
+	} else {
+		m["Flavor"] = ""
+	}
+	image, ok := m["Image"].(map[string]interface{})
+	if ok {
+		m["Image"] = image["id"]
+	} else {
+		m["Image"] = ""
+	}
+
 	for _, key := range keys {
-		tmp := ""
-		switch key {
-		case "Public IPv4":
-			tmp = fmt.Sprint(m["AccessIPv4"])
-		case "Public IPv6":
-			tmp = fmt.Sprint(m["AccessIPv6"])
-		case "Private IPv4":
-			i, ok := m["Addresses"].(map[string]interface{})
-			if !ok {
-				tmp = ""
-				break
-			}
-			j, ok := i["private"].([]interface{})
-			if !ok || len(j) == 0 {
-				tmp = ""
-				break
-			}
-			i, ok = j[0].(map[string]interface{})
-			if !ok {
-				tmp = ""
-				break
-			}
-			tmp = fmt.Sprint(i["addr"])
-		case "Image":
-			i, ok := m["Image"].(map[string]interface{})
-			if !ok {
-				tmp = ""
-				break
-			}
-			tmp = fmt.Sprint(i["id"])
-		case "Flavor":
-			i, ok := m["Flavor"].(map[string]interface{})
-			if !ok {
-				tmp = ""
-				break
-			}
-			tmp = fmt.Sprint(i["id"])
-		default:
-			tmp = fmt.Sprint(m[key])
-		}
-		if tmp == "<nil>" {
-			tmp = ""
-		}
-		t.Append([]string{key, tmp})
+		t.Append([]string{key, fmt.Sprint(m[key])})
 	}
 	t.Render()
 }

--- a/serverscommands/instancecommands/get.go
+++ b/serverscommands/instancecommands/get.go
@@ -44,5 +44,5 @@ func tableGet(c *cli.Context, i interface{}) {
 	keys := []string{"ID", "Name", "Status", "Created", "Updated", "Image", "Flavor", "Public IPv4", "Public IPv6", "Private IPv4", "KeyName"}
 
 	mungeServerMap(m)
-	util.MetaDataMapPrint(c, m, keys)
+	util.MetaDataMapTable(c, m, keys)
 }

--- a/serverscommands/instancecommands/get.go
+++ b/serverscommands/instancecommands/get.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
-	"github.com/olekukonko/tablewriter"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
 )
 
@@ -42,15 +41,10 @@ func commandGet(c *cli.Context) {
 
 func tableGet(c *cli.Context, i interface{}) {
 	m := structs.Map(i)
-	t := tablewriter.NewWriter(c.App.Writer)
-	t.SetAlignment(tablewriter.ALIGN_LEFT)
-	t.SetHeader([]string{"property", "value"})
 	keys := []string{"ID", "Name", "Status", "Created", "Updated", "Image", "Flavor", "Public IPv4", "Public IPv6", "Private IPv4", "KeyName"}
 
 	mungeServerMap(m)
 
-	for _, key := range keys {
-		t.Append([]string{key, fmt.Sprint(m[key])})
-	}
-	t.Render()
+	util.SimpleMapsTable(c, []map[string]interface{}{m}, keys)
+
 }

--- a/serverscommands/instancecommands/get.go
+++ b/serverscommands/instancecommands/get.go
@@ -44,7 +44,5 @@ func tableGet(c *cli.Context, i interface{}) {
 	keys := []string{"ID", "Name", "Status", "Created", "Updated", "Image", "Flavor", "Public IPv4", "Public IPv6", "Private IPv4", "KeyName"}
 
 	mungeServerMap(m)
-
-	util.SimpleMapsTable(c, []map[string]interface{}{m}, keys)
-
+	util.MetaDataMapPrint(c, m, keys)
 }

--- a/serverscommands/instancecommands/list.go
+++ b/serverscommands/instancecommands/list.go
@@ -170,22 +170,9 @@ func plainList(c *cli.Context, i interface{}) {
 		m := structs.Map(server)
 
 		// Extract the Image ID
-		image := ""
-		i, ok := m["Image"].(map[string]interface{})
-		if !ok {
-			image = ""
-		} else {
-			image = fmt.Sprint(i["id"])
-		}
-
+		image, _ := GetNestedID(m["Image"])
 		// Extract the Flavor ID
-		flavor := ""
-		f, ok := m["Flavor"].(map[string]interface{})
-		if !ok {
-			flavor = "" // This is already assumed, I could skip this
-		} else {
-			flavor = fmt.Sprint(f["id"])
-		}
+		flavor, _ := GetNestedID(m["Flavor"])
 
 		// Extract the very first private address
 		// TODO: How do we handle multiples here?
@@ -206,4 +193,13 @@ func plainList(c *cli.Context, i interface{}) {
 
 	}
 	w.Flush()
+}
+
+// GetNestedID extracts the nested id from, e.g. the flavor from a server
+func GetNestedID(i interface{}) (string, bool) {
+	f, ok := i.(map[string]interface{})
+	if !ok {
+		return "", ok
+	}
+	return fmt.Sprint(f["id"]), ok
 }

--- a/serverscommands/instancecommands/list.go
+++ b/serverscommands/instancecommands/list.go
@@ -102,12 +102,3 @@ func tableList(c *cli.Context, i interface{}) {
 	util.SimpleMapsTable(c, maps, keys)
 
 }
-
-// GetNestedID extracts the nested id from, e.g. the flavor from a server
-func GetNestedID(i interface{}) (string, bool) {
-	f, ok := i.(map[string]interface{})
-	if !ok {
-		return "", ok
-	}
-	return fmt.Sprint(f["id"]), ok
-}

--- a/serverscommands/instancecommands/list.go
+++ b/serverscommands/instancecommands/list.go
@@ -3,8 +3,6 @@ package instancecommands
 import (
 	"fmt"
 	"os"
-	"strings"
-	"text/tabwriter"
 
 	"github.com/codegangsta/cli"
 	"github.com/fatih/structs"
@@ -94,19 +92,15 @@ func tableList(c *cli.Context, i interface{}) {
 
 	keys := []string{"ID", "Name", "Status", "Public IPv4", "Private IPv4", "Image", "Flavor"}
 
-	w := new(tabwriter.Writer)
-	w.Init(c.App.Writer, 0, 8, 0, '\t', 0)
-
-	// Write the header
-	fmt.Fprintln(w, strings.Join(keys, "\t"))
+	var maps []map[string]interface{}
 	for _, server := range servers {
 		m := structs.Map(server)
 		mungeServerMap(m)
-
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", m["ID"], m["Name"], m["Status"], m["AccessIPv4"], m["Private IPv4"], m["Image"], m["Flavor"])
-
+		maps = append(maps, m)
 	}
-	w.Flush()
+
+	util.SimpleMapsTable(c, maps, keys)
+
 }
 
 // GetNestedID extracts the nested id from, e.g. the flavor from a server

--- a/serverscommands/instancecommands/list.go
+++ b/serverscommands/instancecommands/list.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
-	"github.com/olekukonko/tablewriter"
 	osServers "github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
 )
@@ -82,77 +81,11 @@ func commandList(c *cli.Context) {
 		fmt.Printf("Error listing servers: %s\n", err)
 		os.Exit(1)
 	}
-	//output.Print(c, o, tableList)
 
-	output.Print(c, o, plainList)
+	output.Print(c, o, tableList)
 }
 
 func tableList(c *cli.Context, i interface{}) {
-	servers, ok := i.([]osServers.Server)
-	if !ok {
-		fmt.Fprintf(c.App.Writer, "Could not type assert interface\n%+v\nto []osServers.Server\n", i)
-		os.Exit(1)
-	}
-
-	keys := []string{"ID", "Name", "Status", "Public IPv4", "Private IPv4", "Image", "Flavor"}
-
-	t := tablewriter.NewWriter(c.App.Writer)
-	t.SetAlignment(tablewriter.ALIGN_LEFT)
-
-	t.SetHeader(keys)
-	for _, server := range servers {
-		m := structs.Map(server)
-		f := []string{}
-		for _, key := range keys {
-			tmp := ""
-			switch key {
-			case "Public IPv4":
-				tmp = fmt.Sprint(m["AccessIPv4"])
-			case "Private IPv4":
-				i, ok := m["Addresses"].(map[string]interface{})
-				if !ok {
-					tmp = ""
-					break
-				}
-				j, ok := i["private"].([]interface{})
-				if !ok || len(j) == 0 {
-					tmp = ""
-					break
-				}
-				i, ok = j[0].(map[string]interface{})
-				if !ok {
-					tmp = ""
-					break
-				}
-				tmp = fmt.Sprint(i["addr"])
-			case "Image":
-				i, ok := m["Image"].(map[string]interface{})
-				if !ok {
-					tmp = ""
-					break
-				}
-				tmp = fmt.Sprint(i["id"])
-			case "Flavor":
-				i, ok := m["Flavor"].(map[string]interface{})
-				if !ok {
-					tmp = ""
-					break
-				}
-				tmp = fmt.Sprint(i["id"])
-			default:
-				tmp = fmt.Sprint(m[key])
-			}
-			if tmp == "<nil>" {
-				tmp = ""
-			}
-			f = append(f, tmp)
-		}
-		t.Append(f)
-	}
-	t.Render()
-}
-
-func plainList(c *cli.Context, i interface{}) {
 	servers, ok := i.([]osServers.Server)
 	if !ok {
 		fmt.Fprintf(c.App.Writer, "Could not type assert interface\n%+v\nto []osServers.Server\n", i)

--- a/serverscommands/instancecommands/list.go
+++ b/serverscommands/instancecommands/list.go
@@ -162,7 +162,7 @@ func plainList(c *cli.Context, i interface{}) {
 	keys := []string{"ID", "Name", "Status", "Public IPv4", "Private IPv4", "Image", "Flavor"}
 
 	w := new(tabwriter.Writer)
-	w.Init(c.App.Writer, 20, 1, 3, ' ', 0)
+	w.Init(c.App.Writer, 0, 8, 0, '\t', 0)
 
 	// Write the header
 	fmt.Fprintln(w, strings.Join(keys, "\t"))

--- a/serverscommands/instancecommands/list.go
+++ b/serverscommands/instancecommands/list.go
@@ -99,6 +99,6 @@ func tableList(c *cli.Context, i interface{}) {
 		maps = append(maps, m)
 	}
 
-	util.Table(c, maps, keys)
+	util.ListTable(c, maps, keys)
 
 }

--- a/serverscommands/instancecommands/list.go
+++ b/serverscommands/instancecommands/list.go
@@ -169,9 +169,10 @@ func plainList(c *cli.Context, i interface{}) {
 	for _, server := range servers {
 		m := structs.Map(server)
 
-		// Extract the Image ID
+		// Extract the Image ID - if !ok, image is ""
 		image, _ := GetNestedID(m["Image"])
-		// Extract the Flavor ID
+
+		// Extract the Flavor ID - if !ok, flavor is ""
 		flavor, _ := GetNestedID(m["Flavor"])
 
 		// Extract the very first private address

--- a/serverscommands/instancecommands/list.go
+++ b/serverscommands/instancecommands/list.go
@@ -99,6 +99,6 @@ func tableList(c *cli.Context, i interface{}) {
 		maps = append(maps, m)
 	}
 
-	util.SimpleMapsTable(c, maps, keys)
+	util.Table(c, maps, keys)
 
 }

--- a/serverscommands/instancecommands/list.go
+++ b/serverscommands/instancecommands/list.go
@@ -101,38 +101,7 @@ func tableList(c *cli.Context, i interface{}) {
 	fmt.Fprintln(w, strings.Join(keys, "\t"))
 	for _, server := range servers {
 		m := structs.Map(server)
-
-		m["Public IPv4"] = m["AccessIPv4"]
-		m["Public IPv6"] = m["AccessIPv6"]
-
-		// Private IPv4 case
-		// Nested m["Addresses"]["private"][0]
-		addrs, ok := m["Addresses"].(map[string]interface{})
-		if ok {
-			ips, ok := addrs["private"].([]interface{})
-			if ok || len(ips) > 0 {
-				priv, ok := ips[0].(map[string]interface{})
-				if ok {
-					m["Private IPv4"] = priv["addr"]
-				}
-			}
-		}
-		if !ok { // if any were not ok, set the field to blank
-			m["Private IPv4"] = ""
-		}
-
-		flavor, ok := m["Flavor"].(map[string]interface{})
-		if ok {
-			m["Flavor"] = flavor["id"]
-		} else {
-			m["Flavor"] = ""
-		}
-		image, ok := m["Image"].(map[string]interface{})
-		if ok {
-			m["Image"] = image["id"]
-		} else {
-			m["Image"] = ""
-		}
+		mungeServerMap(m)
 
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", m["ID"], m["Name"], m["Status"], m["AccessIPv4"], m["Private IPv4"], m["Image"], m["Flavor"])
 

--- a/serverscommands/instancecommands/update.go
+++ b/serverscommands/instancecommands/update.go
@@ -63,5 +63,5 @@ func tableUpdate(c *cli.Context, i interface{}) {
 	m := structs.Map(i)
 	keys := []string{"ID", "Name", "Public IPv4", "Public IPv6"}
 	mungeServerMap(m)
-	util.MetaDataMapPrint(c, m, keys)
+	util.MetaDataMapTable(c, m, keys)
 }

--- a/serverscommands/instancecommands/update.go
+++ b/serverscommands/instancecommands/update.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
-	"github.com/olekukonko/tablewriter"
 	osServers "github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
 )
@@ -62,24 +61,7 @@ func commandUpdate(c *cli.Context) {
 
 func tableUpdate(c *cli.Context, i interface{}) {
 	m := structs.Map(i)
-	t := tablewriter.NewWriter(c.App.Writer)
-	t.SetAlignment(tablewriter.ALIGN_LEFT)
-	t.SetHeader([]string{"property", "value"})
 	keys := []string{"ID", "Name", "Public IPv4", "Public IPv6"}
-	for _, key := range keys {
-		tmp := ""
-		switch key {
-		case "Public IPv4":
-			tmp = fmt.Sprint(m["AccessIPv4"])
-		case "Public IPv6":
-			tmp = fmt.Sprint(m["AccessIPv6"])
-		default:
-			tmp = fmt.Sprint(m[key])
-		}
-		if tmp == "<nil>" {
-			tmp = ""
-		}
-		t.Append([]string{key, tmp})
-	}
-	t.Render()
+	mungeServerMap(m)
+	util.MetaDataMapPrint(c, m, keys)
 }

--- a/serverscommands/keypaircommands/create.go
+++ b/serverscommands/keypaircommands/create.go
@@ -62,5 +62,6 @@ func commandCreate(c *cli.Context) {
 }
 
 func tableCreate(c *cli.Context, i interface{}) {
-	util.MetaDataPrint(c, i, []string{"Name", "Fingerprint", "PublicKey", "PrivateKey"})
+	keys := []string{"Name", "Fingerprint", "PublicKey", "PrivateKey"}
+	util.MetaDataPrint(c, i, keys)
 }

--- a/serverscommands/keypaircommands/create.go
+++ b/serverscommands/keypaircommands/create.go
@@ -63,5 +63,5 @@ func commandCreate(c *cli.Context) {
 
 func tableCreate(c *cli.Context, i interface{}) {
 	keys := []string{"Name", "Fingerprint", "PublicKey", "PrivateKey"}
-	util.MetaDataPrint(c, i, keys)
+	util.MetaDataTable(c, i, keys)
 }

--- a/serverscommands/keypaircommands/create.go
+++ b/serverscommands/keypaircommands/create.go
@@ -4,11 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
-	"text/tabwriter"
 
 	"github.com/codegangsta/cli"
-	"github.com/fatih/structs"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
@@ -65,16 +62,5 @@ func commandCreate(c *cli.Context) {
 }
 
 func tableCreate(c *cli.Context, i interface{}) {
-	m := structs.Map(i)
-	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 0, '\t', 0)
-
-	fmt.Fprintln(w, "PROPERTY\tVALUE")
-
-	keys := []string{"Name", "Fingerprint", "PublicKey", "PrivateKey"}
-	for _, key := range keys {
-		val := fmt.Sprintf("%s", m[key])
-		fmt.Fprintf(w, "%s\t%s\n", key, strings.Replace(val, "\n", "\n\t", -1))
-	}
-	w.Flush()
-
+	util.MetaDataPrint(c, i, []string{"Name", "Fingerprint", "PublicKey", "PrivateKey"})
 }

--- a/serverscommands/keypaircommands/delete.go
+++ b/serverscommands/keypaircommands/delete.go
@@ -5,9 +5,9 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
-	"github.com/jrperritt/gophercloud/rackspace/compute/v2/keypairs"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/util"
+	"github.com/rackspace/gophercloud/rackspace/compute/v2/keypairs"
 )
 
 var remove = cli.Command{

--- a/serverscommands/keypaircommands/get.go
+++ b/serverscommands/keypaircommands/get.go
@@ -5,10 +5,8 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
-	"github.com/fatih/structs"
 	"github.com/jrperritt/gophercloud/rackspace/compute/v2/keypairs"
 	"github.com/jrperritt/rack/auth"
-	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
 )
 
@@ -36,10 +34,6 @@ func commandGet(c *cli.Context) {
 		fmt.Printf("Error retreiving image [%s]: %s\n", flavorID, err)
 		os.Exit(1)
 	}
-	output.Print(c, o, keyGet)
-}
 
-func keyGet(c *cli.Context, i interface{}) {
-	m := structs.Map(i)
-	fmt.Fprintf(c.App.Writer, "%s", m["PublicKey"])
+	fmt.Fprintf(c.App.Writer, "%s", o.PublicKey)
 }

--- a/serverscommands/keypaircommands/get.go
+++ b/serverscommands/keypaircommands/get.go
@@ -35,5 +35,6 @@ func commandGet(c *cli.Context) {
 		os.Exit(1)
 	}
 
+	// Assume they want the key directly
 	fmt.Fprintf(c.App.Writer, "%s", o.PublicKey)
 }

--- a/serverscommands/keypaircommands/get.go
+++ b/serverscommands/keypaircommands/get.go
@@ -5,9 +5,9 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
-	"github.com/jrperritt/gophercloud/rackspace/compute/v2/keypairs"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/util"
+	"github.com/rackspace/gophercloud/rackspace/compute/v2/keypairs"
 )
 
 var get = cli.Command{

--- a/serverscommands/keypaircommands/get.go
+++ b/serverscommands/keypaircommands/get.go
@@ -3,7 +3,6 @@ package keypaircommands
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/codegangsta/cli"
 	"github.com/fatih/structs"
@@ -11,7 +10,6 @@ import (
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
-	"github.com/olekukonko/tablewriter"
 )
 
 var get = cli.Command{
@@ -38,31 +36,10 @@ func commandGet(c *cli.Context) {
 		fmt.Printf("Error retreiving image [%s]: %s\n", flavorID, err)
 		os.Exit(1)
 	}
-	output.Print(c, o, tableGet)
+	output.Print(c, o, keyGet)
 }
 
-func tableGet(c *cli.Context, i interface{}) {
+func keyGet(c *cli.Context, i interface{}) {
 	m := structs.Map(i)
-	t := tablewriter.NewWriter(c.App.Writer)
-	colWidth := 100
-	t.SetColWidth(colWidth)
-	t.SetAlignment(tablewriter.ALIGN_LEFT)
-	t.SetHeader([]string{"property", "value"})
-	keys := []string{"Name", "Fingerprint"}
-	for _, key := range keys {
-		t.Append([]string{key, fmt.Sprint(m[key])})
-	}
-	t.Render()
-	keyWidth := tablewriter.DisplayWidth(m["PublicKey"].(string))
-	numPieces := keyWidth / colWidth
-	remainder := keyWidth % colWidth
-	pieces := make([]string, numPieces)
-	j := 0
-	for j = 0; j < numPieces; {
-		pieces = append(pieces, m["PublicKey"].(string)[colWidth*j:colWidth*j+colWidth])
-		j++
-	}
-	pieces = append(pieces, m["PublicKey"].(string)[colWidth*j:colWidth*j+remainder])
-	pk := strings.TrimLeft(strings.Join(pieces, "\n"), "\n")
-	fmt.Printf("PublicKey: %s\n", pk)
+	fmt.Fprintf(c.App.Writer, "%s", m["PublicKey"])
 }

--- a/serverscommands/keypaircommands/list.go
+++ b/serverscommands/keypaircommands/list.go
@@ -58,6 +58,6 @@ func tableList(c *cli.Context, i interface{}) {
 		maps = append(maps, structs.Map(kp))
 	}
 
-	util.SimpleMapsTable(c, maps, keys)
+	util.Table(c, maps, keys)
 
 }

--- a/serverscommands/keypaircommands/list.go
+++ b/serverscommands/keypaircommands/list.go
@@ -3,13 +3,14 @@ package keypaircommands
 import (
 	"fmt"
 	"os"
+	"strings"
+	"text/tabwriter"
 
 	"github.com/codegangsta/cli"
 	"github.com/fatih/structs"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
-	"github.com/olekukonko/tablewriter"
 	osKeypairs "github.com/rackspace/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/keypairs"
 )
@@ -51,16 +52,17 @@ func tableList(c *cli.Context, i interface{}) {
 		fmt.Fprintf(c.App.Writer, "Could not type assert interface\n%+v\nto []osKeypairs.KeyPair\n", i)
 		os.Exit(1)
 	}
-	t := tablewriter.NewWriter(c.App.Writer)
+
 	keys := []string{"Name", "Fingerprint"}
-	t.SetHeader(keys)
+
+	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 0, '\t', 0)
+
+	// Write the header
+	fmt.Fprintln(w, strings.Join(keys, "\t"))
+
 	for _, kp := range kps {
 		m := structs.Map(kp)
-		f := []string{}
-		for _, key := range keys {
-			f = append(f, fmt.Sprint(m[key]))
-		}
-		t.Append(f)
+		fmt.Fprintf(w, "%s\t%s\n", m["Name"], m["Fingerprint"])
 	}
-	t.Render()
+	w.Flush()
 }

--- a/serverscommands/keypaircommands/list.go
+++ b/serverscommands/keypaircommands/list.go
@@ -3,8 +3,6 @@ package keypaircommands
 import (
 	"fmt"
 	"os"
-	"strings"
-	"text/tabwriter"
 
 	"github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/auth"
@@ -54,13 +52,9 @@ func tableList(c *cli.Context, i interface{}) {
 
 	keys := []string{"Name", "Fingerprint"}
 
-	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 0, '\t', 0)
-
-	// Write the header
-	fmt.Fprintln(w, strings.Join(keys, "\t"))
-
-	for _, kp := range kps {
-		fmt.Fprintf(w, "%s\t%s\n", kp.Name, kp.Fingerprint)
+	is := make([]interface{}, len(kps))
+	for i, d := range kps {
+		is[i] = d
 	}
-	w.Flush()
+	util.SimpleListing(c, keys, is)
 }

--- a/serverscommands/keypaircommands/list.go
+++ b/serverscommands/keypaircommands/list.go
@@ -7,7 +7,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/codegangsta/cli"
-	"github.com/fatih/structs"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
@@ -61,8 +60,7 @@ func tableList(c *cli.Context, i interface{}) {
 	fmt.Fprintln(w, strings.Join(keys, "\t"))
 
 	for _, kp := range kps {
-		m := structs.Map(kp)
-		fmt.Fprintf(w, "%s\t%s\n", m["Name"], m["Fingerprint"])
+		fmt.Fprintf(w, "%s\t%s\n", kp.Name, kp.Fingerprint)
 	}
 	w.Flush()
 }

--- a/serverscommands/keypaircommands/list.go
+++ b/serverscommands/keypaircommands/list.go
@@ -56,5 +56,5 @@ func tableList(c *cli.Context, i interface{}) {
 	for i, d := range kps {
 		is[i] = d
 	}
-	util.SimpleListing(c, keys, is)
+	util.SimpleListing(c, is, keys)
 }

--- a/serverscommands/keypaircommands/list.go
+++ b/serverscommands/keypaircommands/list.go
@@ -58,6 +58,6 @@ func tableList(c *cli.Context, i interface{}) {
 		maps = append(maps, structs.Map(kp))
 	}
 
-	util.Table(c, maps, keys)
+	util.ListTable(c, maps, keys)
 
 }

--- a/serverscommands/keypaircommands/list.go
+++ b/serverscommands/keypaircommands/list.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
+	"github.com/fatih/structs"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
@@ -52,9 +53,11 @@ func tableList(c *cli.Context, i interface{}) {
 
 	keys := []string{"Name", "Fingerprint"}
 
-	is := make([]interface{}, len(kps))
-	for i, d := range kps {
-		is[i] = d
+	var maps []map[string]interface{}
+	for _, kp := range kps {
+		maps = append(maps, structs.Map(kp))
 	}
-	util.SimpleListing(c, is, keys)
+
+	util.SimpleMapsTable(c, maps, keys)
+
 }

--- a/util/util.go
+++ b/util/util.go
@@ -95,51 +95,6 @@ func CheckKVFlag(c *cli.Context, flagName string) map[string]string {
 	return kv
 }
 
-// MetaDataPrint writes standardized metadata out
-func MetaDataPrint(c *cli.Context, i interface{}, keys []string) {
-	m := structs.Map(i)
-	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 0, '\t', 0)
-
-	fmt.Fprintln(w, "PROPERTY\tVALUE")
-
-	for _, key := range keys {
-		val := fmt.Sprint(m[key])
-		fmt.Fprintf(w, "%s\t%s\n", key, strings.Replace(val, "\n", "\n\t", -1))
-	}
-	w.Flush()
-}
-
-// SimpleListing writes a simple table out
-// Example creation of the interface slice for your type:
-//
-//   	kps, ok := i.([]osKeypairs.KeyPair)
-//    // Make sure to check "ok"
-//
-//    is := make([]interface{}, len(kps))
-//    for i, d := range kps {
-//   	  is[i] = d
-//    }
-//
-// The reason you have to do this initial setup is that []interface{} has a
-// specific memory layout known at compile time.
-//
-// See https://github.com/golang/go/wiki/InterfaceSlice
-func SimpleListing(c *cli.Context, many []interface{}, keys []string) {
-	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 1, '\t', 0)
-	// Write the header
-	fmt.Fprintln(w, strings.Join(keys, "\t"))
-
-	for _, i := range many {
-		m := structs.Map(i)
-		f := []string{}
-		for _, key := range keys {
-			f = append(f, fmt.Sprint(m[key]))
-		}
-		fmt.Fprintln(w, strings.Join(f, "\t"))
-	}
-	w.Flush()
-}
-
 // SimpleMapsTable writes a table listing from an array of map[string]interface{}
 func SimpleMapsTable(c *cli.Context, many []map[string]interface{}, keys []string) {
 	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 1, '\t', 0)
@@ -147,18 +102,16 @@ func SimpleMapsTable(c *cli.Context, many []map[string]interface{}, keys []strin
 	fmt.Fprintln(w, strings.Join(keys, "\t"))
 
 	for _, m := range many {
-		WriteMapEntry(w, m, keys)
+		writeMapEntry(w, m, keys)
 	}
 	w.Flush()
 }
 
-// WriteMapEntry writes a table entry from a map
-func WriteMapEntry(w *tabwriter.Writer, m map[string]interface{}, keys []string) {
-	f := []string{}
-	for _, key := range keys {
-		f = append(f, fmt.Sprint(m[key]))
-	}
-	fmt.Fprintln(w, strings.Join(f, "\t"))
+// MetaDataPrint writes standardized metadata out
+func MetaDataPrint(c *cli.Context, i interface{}, keys []string) {
+	m := structs.Map(i)
+
+	MetaDataMapPrint(c, m, keys)
 }
 
 // MetaDataMapPrint writes standardized metadata out
@@ -172,4 +125,13 @@ func MetaDataMapPrint(c *cli.Context, m map[string]interface{}, keys []string) {
 		fmt.Fprintf(w, "%s\t%s\n", key, strings.Replace(val, "\n", "\n\t", -1))
 	}
 	w.Flush()
+}
+
+// writeMapEntry writes a table entry from a map
+func writeMapEntry(w *tabwriter.Writer, m map[string]interface{}, keys []string) {
+	f := []string{}
+	for _, key := range keys {
+		f = append(f, fmt.Sprint(m[key]))
+	}
+	fmt.Fprintln(w, strings.Join(f, "\t"))
 }

--- a/util/util.go
+++ b/util/util.go
@@ -109,9 +109,9 @@ func MetaDataPrint(c *cli.Context, i interface{}, keys []string) {
 	w.Flush()
 }
 
-// SimpleTable writes a simple table out
-func SimpleTable(c *cli.Context, keys []string, many []interface{}) {
-	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 0, '\t', 0)
+// SimpleListing writes a simple table out
+func SimpleListing(c *cli.Context, keys []string, many []interface{}) {
+	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 1, '\t', 0)
 	// Write the header
 	fmt.Fprintln(w, strings.Join(keys, "\t"))
 

--- a/util/util.go
+++ b/util/util.go
@@ -95,8 +95,8 @@ func CheckKVFlag(c *cli.Context, flagName string) map[string]string {
 	return kv
 }
 
-// SimpleMapsTable writes a table listing from an array of map[string]interface{}
-func SimpleMapsTable(c *cli.Context, many []map[string]interface{}, keys []string) {
+// Table writes a table listing from an array of map[string]interface{}
+func Table(c *cli.Context, many []map[string]interface{}, keys []string) {
 	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 1, '\t', 0)
 	// Write the header
 	fmt.Fprintln(w, strings.Join(keys, "\t"))
@@ -107,15 +107,15 @@ func SimpleMapsTable(c *cli.Context, many []map[string]interface{}, keys []strin
 	w.Flush()
 }
 
-// MetaDataPrint writes standardized metadata out
-func MetaDataPrint(c *cli.Context, i interface{}, keys []string) {
+// MetaDataTable writes standardized metadata out
+// Solely a utility method that invokes MetaDataMapTable with structs.Map(i)
+func MetaDataTable(c *cli.Context, i interface{}, keys []string) {
 	m := structs.Map(i)
-
-	MetaDataMapPrint(c, m, keys)
+	MetaDataMapTable(c, m, keys)
 }
 
-// MetaDataMapPrint writes standardized metadata out
-func MetaDataMapPrint(c *cli.Context, m map[string]interface{}, keys []string) {
+// MetaDataMapTable writes standardized metadata out
+func MetaDataMapTable(c *cli.Context, m map[string]interface{}, keys []string) {
 	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 0, '\t', 0)
 
 	fmt.Fprintln(w, "PROPERTY\tVALUE")

--- a/util/util.go
+++ b/util/util.go
@@ -110,7 +110,21 @@ func MetaDataPrint(c *cli.Context, i interface{}, keys []string) {
 }
 
 // SimpleListing writes a simple table out
-func SimpleListing(c *cli.Context, keys []string, many []interface{}) {
+// Example creation of the interface slice for your type:
+//
+//   	kps, ok := i.([]osKeypairs.KeyPair)
+//    // Make sure to check "ok"
+//
+//    is := make([]interface{}, len(kps))
+//    for i, d := range kps {
+//   	  is[i] = d
+//    }
+//
+// The reason you have to do this initial setup is that []interface{} has a
+// specific memory layout known at compile time.
+//
+// See https://github.com/golang/go/wiki/InterfaceSlice
+func SimpleListing(c *cli.Context, many []interface{}, keys []string) {
 	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 1, '\t', 0)
 	// Write the header
 	fmt.Fprintln(w, strings.Join(keys, "\t"))

--- a/util/util.go
+++ b/util/util.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/codegangsta/cli"
+	"github.com/fatih/structs"
 )
 
 // Name is the name of the CLI
@@ -91,4 +93,19 @@ func CheckKVFlag(c *cli.Context, flagName string) map[string]string {
 		kv[temp[0]] = temp[1]
 	}
 	return kv
+}
+
+// MetaDataPrint writes standardized metadata out
+func MetaDataPrint(c *cli.Context, i interface{}, keys []string) {
+	m := structs.Map(i)
+	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 0, '\t', 0)
+
+	fmt.Fprintln(w, "PROPERTY\tVALUE")
+
+	for _, key := range keys {
+		val := fmt.Sprintf("%s", m[key])
+		fmt.Fprintf(w, "%s\t%s\n", key, strings.Replace(val, "\n", "\n\t", -1))
+	}
+	w.Flush()
+
 }

--- a/util/util.go
+++ b/util/util.go
@@ -95,8 +95,8 @@ func CheckKVFlag(c *cli.Context, flagName string) map[string]string {
 	return kv
 }
 
-// Table writes a table listing from an array of map[string]interface{}
-func Table(c *cli.Context, many []map[string]interface{}, keys []string) {
+// ListTable writes a table listing from an array of map[string]interface{}
+func ListTable(c *cli.Context, many []map[string]interface{}, keys []string) {
 	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 1, '\t', 0)
 	// Write the header
 	fmt.Fprintln(w, strings.Join(keys, "\t"))

--- a/util/util.go
+++ b/util/util.go
@@ -103,7 +103,7 @@ func MetaDataPrint(c *cli.Context, i interface{}, keys []string) {
 	fmt.Fprintln(w, "PROPERTY\tVALUE")
 
 	for _, key := range keys {
-		val := fmt.Sprintf("%s", m[key])
+		val := fmt.Sprint(m[key])
 		fmt.Fprintf(w, "%s\t%s\n", key, strings.Replace(val, "\n", "\n\t", -1))
 	}
 	w.Flush()

--- a/util/util.go
+++ b/util/util.go
@@ -160,3 +160,16 @@ func WriteMapEntry(w *tabwriter.Writer, m map[string]interface{}, keys []string)
 	}
 	fmt.Fprintln(w, strings.Join(f, "\t"))
 }
+
+// MetaDataMapPrint writes standardized metadata out
+func MetaDataMapPrint(c *cli.Context, m map[string]interface{}, keys []string) {
+	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 0, '\t', 0)
+
+	fmt.Fprintln(w, "PROPERTY\tVALUE")
+
+	for _, key := range keys {
+		val := fmt.Sprint(m[key])
+		fmt.Fprintf(w, "%s\t%s\n", key, strings.Replace(val, "\n", "\n\t", -1))
+	}
+	w.Flush()
+}

--- a/util/util.go
+++ b/util/util.go
@@ -107,5 +107,20 @@ func MetaDataPrint(c *cli.Context, i interface{}, keys []string) {
 		fmt.Fprintf(w, "%s\t%s\n", key, strings.Replace(val, "\n", "\n\t", -1))
 	}
 	w.Flush()
+}
 
+// SimpleTable writes a simple table out
+func SimpleTable(c *cli.Context, keys []string, many []map[string]interface{}) {
+	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 0, '\t', 0)
+	// Write the header
+	fmt.Fprintln(w, strings.Join(keys, "\t"))
+
+	for _, m := range many {
+		f := []string{}
+		for _, key := range keys {
+			f = append(f, fmt.Sprint(m[key]))
+		}
+		fmt.Fprintln(w, strings.Join(f, "\t"))
+	}
+	w.Flush()
 }

--- a/util/util.go
+++ b/util/util.go
@@ -109,24 +109,14 @@ func MetaDataPrint(c *cli.Context, i interface{}, keys []string) {
 	w.Flush()
 }
 
-// BuildMaps is terrible golang
-func BuildMaps(i []interface{}) []map[string]interface{} {
-	maps := make([]map[string]interface{}, len(i))
-	for _, element := range i {
-		m := structs.Map(element)
-		maps = append(maps, m)
-	}
-
-	return maps
-}
-
 // SimpleTable writes a simple table out
-func SimpleTable(c *cli.Context, keys []string, many []map[string]interface{}) {
+func SimpleTable(c *cli.Context, keys []string, many []interface{}) {
 	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 0, '\t', 0)
 	// Write the header
 	fmt.Fprintln(w, strings.Join(keys, "\t"))
 
-	for _, m := range many {
+	for _, i := range many {
+		m := structs.Map(i)
 		f := []string{}
 		for _, key := range keys {
 			f = append(f, fmt.Sprint(m[key]))

--- a/util/util.go
+++ b/util/util.go
@@ -109,6 +109,17 @@ func MetaDataPrint(c *cli.Context, i interface{}, keys []string) {
 	w.Flush()
 }
 
+// BuildMaps is terrible golang
+func BuildMaps(i []interface{}) []map[string]interface{} {
+	maps := make([]map[string]interface{}, len(i))
+	for _, element := range i {
+		m := structs.Map(element)
+		maps = append(maps, m)
+	}
+
+	return maps
+}
+
 // SimpleTable writes a simple table out
 func SimpleTable(c *cli.Context, keys []string, many []map[string]interface{}) {
 	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 0, '\t', 0)

--- a/util/util.go
+++ b/util/util.go
@@ -139,3 +139,24 @@ func SimpleListing(c *cli.Context, many []interface{}, keys []string) {
 	}
 	w.Flush()
 }
+
+// SimpleMapsTable writes a table listing from an array of map[string]interface{}
+func SimpleMapsTable(c *cli.Context, many []map[string]interface{}, keys []string) {
+	w := tabwriter.NewWriter(c.App.Writer, 0, 8, 1, '\t', 0)
+	// Write the header
+	fmt.Fprintln(w, strings.Join(keys, "\t"))
+
+	for _, m := range many {
+		WriteMapEntry(w, m, keys)
+	}
+	w.Flush()
+}
+
+// WriteMapEntry writes a table entry from a map
+func WriteMapEntry(w *tabwriter.Writer, m map[string]interface{}, keys []string) {
+	f := []string{}
+	for _, key := range keys {
+		f = append(f, fmt.Sprint(m[key]))
+	}
+	fmt.Fprintln(w, strings.Join(f, "\t"))
+}


### PR DESCRIPTION
This uses tabwriter to write out the tables.

```
$ rack servers instance list --name="django.*"
ID                                     Name                Status              Public IPv4         Private IPv4        Image                                  Flavor
4ec0305a-6cd6-4168-a0a4-421c43a9e068   django-0            ACTIVE              104.239.174.85      10.209.71.200       0d83aff5-9910-44aa-a721-1c6b28e3c9dc   general1-4
b2c02434-41e2-403c-84b3-a2f4fc54e454   django-1            ACTIVE              104.239.174.68      10.209.71.165       0d83aff5-9910-44aa-a721-1c6b28e3c9dc   general1-4
```

I've been trying to rectify whether tabs or spaces are better here. With tabs, `cut` is easier to use after. The one I've included here uses spaces in the [same configuration as `docker`](https://github.com/docker/docker/search?utf8=%E2%9C%93&q=tabwriter):

```
tabwriter.NewWriter(cli.out, 20, 1, 3, ' ', 0)
```

(well, I use Init but the args are the same)