### PR TITLE
Adds rename as a flag

### DIFF
--- a/serverscommands/instancecommands/rebuild.go
+++ b/serverscommands/instancecommands/rebuild.go
@@ -88,9 +88,7 @@ func commandRebuild(c *cli.Context) {
 
 	if c.IsSet("rename") {
 		opts.Name = c.String("rename")
-	} else if c.IsSet("name") { // If name specified, assume
-		opts.Name = c.String("name")
-	} else {
+	} else if c.IsSet("id") { // Must get the name from compute by ID
 		getResult := osServers.Get(client, serverID)
 		serverResult, err := getResult.Extract()
 		if err != nil {
@@ -98,6 +96,9 @@ func commandRebuild(c *cli.Context) {
 			os.Exit(1)
 		}
 		opts.Name = serverResult.Name
+	} else if c.IsSet("name") {
+		// Did not set rename, did not set id, can assume name
+		opts.Name = c.String("name")
 	}
 
 	o, err := servers.Rebuild(client, serverID, opts).Extract()

--- a/serverscommands/instancecommands/rebuild.go
+++ b/serverscommands/instancecommands/rebuild.go
@@ -89,10 +89,9 @@ func commandRebuild(c *cli.Context) {
 	if c.IsSet("rename") {
 		opts.Name = c.String("rename")
 	} else if c.IsSet("id") { // Must get the name from compute by ID
-		getResult := osServers.Get(client, serverID)
-		serverResult, err := getResult.Extract()
+		serverResult, err := servers.Get(client, serverID).Extract()
 		if err != nil {
-			fmt.Printf("Error rebuilding server (%s): %s\n", serverID, err)
+			fmt.Printf("Error retrieving server (%s) for rebuild: %s\n", serverID, err)
 			os.Exit(1)
 		}
 		opts.Name = serverResult.Name

--- a/serverscommands/instancecommands/rebuild.go
+++ b/serverscommands/instancecommands/rebuild.go
@@ -75,10 +75,6 @@ func commandRebuild(c *cli.Context) {
 		AccessIPv6: c.String("accessIPv6"),
 	}
 
-	if c.IsSet("rename") {
-		opts.Name = c.String("rename")
-	}
-
 	if c.IsSet("metadata") {
 		opts.Metadata = util.CheckKVFlag(c, "metadata")
 	}


### PR DESCRIPTION
Name has a dual use within rebuild, unintentionally renaming if they specified id and name. If they want to rebuild and specify by name, there's not a way. Overall that breaks our consistency.

In order to straddle ID being specified and the fact that osServers.RebuildOpts expects Name to be set, this also pulls the name from compute by ID.