### PR TITLE
Ensure plain dump happens separately.

### DIFF
--- a/serverscommands/keypaircommands/get.go
+++ b/serverscommands/keypaircommands/get.go
@@ -5,7 +5,9 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
+	"github.com/fatih/structs"
 	"github.com/jrperritt/rack/auth"
+	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/keypairs"
 )
@@ -35,6 +37,12 @@ func commandGet(c *cli.Context) {
 		os.Exit(1)
 	}
 
+	output.Print(c, o, plainGet)
+
+}
+
+func plainGet(c *cli.Context, i interface{}) {
+	m := structs.Map(i)
 	// Assume they want the key directly
-	fmt.Fprintf(c.App.Writer, "%s", o.PublicKey)
+	fmt.Fprintf(c.App.Writer, "%s", m["PublicKey"])
 }


### PR DESCRIPTION
Fixes regression introduced in #21.

```
rack servers keypair get mykey --json
```

was returning plaintext rather than JSON because it didn't go through the output path.