### PR TITLE
Support ARM, which also means raspberry pi!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - GIMME_OS=linux GIMME_ARCH=amd64
     - GIMME_OS=darwin GIMME_ARCH=amd64
     - GIMME_OS=windows GIMME_ARCH=amd64
+    - GIMME_OS=linux GIMME_ARCH=arm
 
 install:
     - go get -d -v ./...


### PR DESCRIPTION
As noted in #37, if we build for ARM (which costs us nothing) we get support on the Raspberry Pi.