### PR TITLE
Indent JSON output.

### DIFF
--- a/output/json.go
+++ b/output/json.go
@@ -6,17 +6,18 @@ import (
 	"io"
 )
 
+// INDENT is the indentation passed to json.MarshalIndent
+const INDENT string = "  "
+
 // JSON prints results in JSON format.
 func defaultJSON(w io.Writer, i interface{}) {
 	m := map[string]interface{}{"result": i}
-	j, _ := json.Marshal(m)
-	fmt.Fprintf(w, "%v", string(j))
+	jsonOut(w, m)
 }
 
 func metadataJSON(w io.Writer, m map[string]interface{}, keys []string) {
 	mLimited := limitJSONFields(m, keys)
-	j, _ := json.Marshal(mLimited)
-	fmt.Fprintf(w, "%v", string(j))
+	jsonOut(w, mLimited)
 }
 
 func listJSON(w io.Writer, maps []map[string]interface{}, keys []string) {
@@ -24,8 +25,7 @@ func listJSON(w io.Writer, maps []map[string]interface{}, keys []string) {
 	for i, m := range maps {
 		mLimited[i] = limitJSONFields(m, keys)
 	}
-	j, _ := json.Marshal(mLimited)
-	fmt.Fprintf(w, "%v", string(j))
+	jsonOut(w, mLimited)
 }
 
 func limitJSONFields(m map[string]interface{}, keys []string) map[string]interface{} {
@@ -36,4 +36,9 @@ func limitJSONFields(m map[string]interface{}, keys []string) map[string]interfa
 		}
 	}
 	return mLimited
+}
+
+func jsonOut(w io.Writer, i interface{}) {
+	j, _ := json.MarshalIndent(i, "", INDENT)
+	fmt.Fprintln(w, string(j))
 }


### PR DESCRIPTION
Closes #44. Simply indents with two spaces on Marshalling.

```
$ ./rack servers flavor list --json | head -n 20
[
  {
    "Disk": 20,
    "ID": "2",
    "Name": "512MB Standard Instance",
    "RAM": 512,
    "RxTxFactor": 80,
    "Swap": 512,
    "VCPUs": 1
  },
  {
    "Disk": 40,
    "ID": "3",
    "Name": "1GB Standard Instance",
    "RAM": 1024,
    "RxTxFactor": 120,
    "Swap": 1024,
    "VCPUs": 1
  },
  {
...
```

Looked at two isatty functions (not part of stdlib):

* golang.org/x/crypto/ssh/terminal - most recommended, but appears to only support *nix variants
* github.com/mattn/go-isatty - supports BSD, *nix, Windows; not sure how well tested