### PR TITLE
Notifications to slack on builds of master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,18 @@
 language: go
 go:
 - 1.4
-
 sudo: false
-
 env:
-    - GIMME_OS=linux GIMME_ARCH=amd64
-    - GIMME_OS=darwin GIMME_ARCH=amd64
-    - GIMME_OS=windows GIMME_ARCH=amd64
-    - GIMME_OS=linux GIMME_ARCH=arm GOARM=5
-    - GIMME_OS=linux GIMME_ARCH=arm GOARM=6
-    - GIMME_OS=linux GIMME_ARCH=arm GOARM=7
-
+- GIMME_OS=linux GIMME_ARCH=amd64
+- GIMME_OS=darwin GIMME_ARCH=amd64
+- GIMME_OS=windows GIMME_ARCH=amd64
+- GIMME_OS=linux GIMME_ARCH=arm GOARM=5
+- GIMME_OS=linux GIMME_ARCH=arm GOARM=6
+- GIMME_OS=linux GIMME_ARCH=arm GOARM=7
 install:
-    - go get -d -v ./...
-
+- go get -d -v ./...
 script:
-    - go build -v ./...
-
+- go build -v ./...
 before_deploy:
 - "./script/prep-travis-release.sh"
 - cd build
@@ -31,3 +26,6 @@ deploy:
   skip_cleanup: true
   on:
     all_branches: true
+notifications:
+  slack:
+    secure: GGxapXtJ6ijPWdFdIypPwuz9nDvKbj1cmLf0edmRBDNTLbg2a1RPyFugxJbd2hEqak62m5Ue3ppY+J+boJXP2n1Eb/FOQelZd3V3lxNPpvoYgJzzq+g/TlSLakposn30PG3ySOAvtvIwGbUrbVsVS3ASBzt9s39N3HoE1CufUDA=


### PR DESCRIPTION
This adds notifications to slack. It only displays the status of builds of master (and any branches on the main repo), because the credentials are encrypted.