### PR TITLE
Streamline build inst

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
 - GIMME_OS=linux GIMME_ARCH=amd64
 - GIMME_OS=darwin GIMME_ARCH=amd64
 - GIMME_OS=windows GIMME_ARCH=amd64
-- GIMME_OS=linux GIMME_ARCH=arm GOARM=5
 - GIMME_OS=linux GIMME_ARCH=arm GOARM=6
 - GIMME_OS=linux GIMME_ARCH=arm GOARM=7
 install:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -27,13 +27,13 @@ OSX and Linux
 After downloading the binary on OSX and Linux you will need to make the binary
 executable by typing::
 
-    chmod a+x /path/to/rack-*
+    chmod a+x /path/to/rack
 
 We also recommend you rename or symbolically link it on these platforms to the
 ``rack`` name::
 
     mkdir -p /usr/local/bin/
-    ln -s /path/to/rack-* /usr/local/bin/rack
+    ln -s /path/to/rack /usr/local/bin/rack
 
 You can now add it to your path with::
 
@@ -103,7 +103,7 @@ For example::
 .. [#] Hush now human. No tears. Only sleep.
 
 .. _go: https://golang.org/
-.. _Mac OSX (64 bit): https://ba7db30ac3f206168dbb-7f12cbe7f0a328a153fa25953cbec5f2.ssl.cf5.rackcdn.com/rack-Darwin
-.. _Linux (64 bit): https://ba7db30ac3f206168dbb-7f12cbe7f0a328a153fa25953cbec5f2.ssl.cf5.rackcdn.com/rack-Linux
-.. _Windows (64 bit): https://ba7db30ac3f206168dbb-7f12cbe7f0a328a153fa25953cbec5f2.ssl.cf5.rackcdn.com/rack.exe
+.. _Mac OSX (64 bit): https://ba7db30ac3f206168dbb-7f12cbe7f0a328a153fa25953cbec5f2.ssl.cf5.rackcdn.com/Darwin/amd64/rack
+.. _Linux (64 bit): https://ba7db30ac3f206168dbb-7f12cbe7f0a328a153fa25953cbec5f2.ssl.cf5.rackcdn.com/Linux/amd64/rack
+.. _Windows (64 bit): https://ba7db30ac3f206168dbb-7f12cbe7f0a328a153fa25953cbec5f2.ssl.cf5.rackcdn.com/Windows/amd64/rack.exe
 .. _Cloud Control panel: https://mycloud.rackspace.com/

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -27,13 +27,13 @@ OSX and Linux
 After downloading the binary on OSX and Linux you will need to make the binary
 executable by typing::
 
-    chmod a+x /path/to/rack-*-amd64
+    chmod a+x /path/to/rack-*
 
 We also recommend you rename or symbolically link it on these platforms to the
 ``rack`` name::
 
     mkdir -p /usr/local/bin/
-    ln -s /path/to/rack-*-amd64 /usr/local/bin/rack
+    ln -s /path/to/rack-* /usr/local/bin/rack
 
 You can now add it to your path with::
 
@@ -44,10 +44,10 @@ Windows
 
 After downloading the binary on Windows, you can immediately run it.
 
-We recommend that you rename the executable to ``rack.exe``, copy it to a location outside of your Downloads folder (e.g. C:\\tools) and add that location to your PATH. You must open a new command prompt after modifying the PATH variable.
+We recommend that you copy it to a location outside of your Downloads folder (e.g. C:\\tools) and add that location to your PATH. You must open a new command prompt after modifying the PATH variable.
 
 1. Create a new directory for command line tools, if you don't already have one, e.g. C:\\tools.
-2. Copy rack-windows-amd64.exe to that directory and rename it to rack.exe.
+2. Copy rack.exe to that directory 
 3. Add the directory to your user's PATH environment variable, e.g. ``setx path "%path%;C:\tools"`` or press the Windows key, type "set env", select "Edit environment variables for your account", select the PATH user variable and append ";C:\\tools" to the value and save your changes.
 4. Open a new command prompt after modifying the PATH variable.
 
@@ -103,7 +103,7 @@ For example::
 .. [#] Hush now human. No tears. Only sleep.
 
 .. _go: https://golang.org/
-.. _Mac OSX (64 bit): https://ba7db30ac3f206168dbb-7f12cbe7f0a328a153fa25953cbec5f2.ssl.cf5.rackcdn.com/rack-darwin-amd64
-.. _Linux (64 bit): https://ba7db30ac3f206168dbb-7f12cbe7f0a328a153fa25953cbec5f2.ssl.cf5.rackcdn.com/rack-linux-amd64
-.. _Windows (64 bit): https://ba7db30ac3f206168dbb-7f12cbe7f0a328a153fa25953cbec5f2.ssl.cf5.rackcdn.com/rack-windows-amd64.exe
+.. _Mac OSX (64 bit): https://ba7db30ac3f206168dbb-7f12cbe7f0a328a153fa25953cbec5f2.ssl.cf5.rackcdn.com/rack-Darwin
+.. _Linux (64 bit): https://ba7db30ac3f206168dbb-7f12cbe7f0a328a153fa25953cbec5f2.ssl.cf5.rackcdn.com/rack-Linux
+.. _Windows (64 bit): https://ba7db30ac3f206168dbb-7f12cbe7f0a328a153fa25953cbec5f2.ssl.cf5.rackcdn.com/rack.exe
 .. _Cloud Control panel: https://mycloud.rackspace.com/

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -29,8 +29,7 @@ executable by typing::
 
     chmod a+x /path/to/rack
 
-We also recommend you rename or symbolically link it on these platforms to the
-``rack`` name::
+We also recommend you move or symbolically link it on these platforms to `/usr/local/bin`::
 
     mkdir -p /usr/local/bin/
     ln -s /path/to/rack /usr/local/bin/rack

--- a/script/prep-travis-release.sh
+++ b/script/prep-travis-release.sh
@@ -18,6 +18,11 @@ IFS=$'\n\t'
 ################################################################################
 set +u
 
+if [[ -z "$GIMME_OS" && -z "$GIMME_ARCH" ]]; then
+  echo "GIMME_OS and GIMME_ARCH must be defined"
+  exit 2
+fi
+
 os=$GIMME_OS
 arch=$GIMME_ARCH
 # See http://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
@@ -37,12 +42,40 @@ fi
 set -u
 ################################################################################
 
-SUFFIX=""
-if [ "$arch" == "arm" ]; then
-  arch="armv${GOARM}"
-fi
-if [ "$os" == "windows" ]; then
-  SUFFIX="${SUFFIX}.exe"
+case $os in
+  windows)
+    os="Windows"
+    ;;
+  linux)
+    os="Linux"
+    ;;
+  darwin)
+    os="Darwin"
+    ;;
+  freebsd)
+    os="FreeBSD"
+    ;;
+  *)
+    echo "Unknown OS ${os}. Assuming it's a valid OS for gimme/go and charging ahead."
+esac
+
+case $arch in
+  arm)
+    # Note that we can never be 1:1 between `uname -m` and arm versions
+    arch="armv${GOARM}"
+    SUFFIX="-${os}-${arch}"
+    ;;
+esac
+
+if [[ "$os" == "Windows" && "$arch" == "amd64" ]]; then
+  SUFFIX=".exe"
+elif [[ "$os" == "Windows" && "$arch" != "amd64" ]]; then
+  SUFFIX="-${arch}.exe"
+elif [ "$arch" == "amd64" ]; then
+  # Assume 64 bit gets to be as is
+  SUFFIX="-${os}"
+else
+  SUFFIX="-${os}-${arch}"
 fi
 
 echo "Building for ${os}-${arch}"
@@ -52,8 +85,8 @@ mkdir -p build
 COMMIT=`git rev-parse HEAD 2> /dev/null`
 mkdir -p "build/commits/${COMMIT}"
 
-BASENAME="rack-${os}-${arch}"
-RACKBUILD="build/${BASENAME}"
+BASENAME="rack"
+RACKBUILD="build/${BASENAME}${SUFFIX}"
 
 go build -o $RACKBUILD
 
@@ -63,8 +96,5 @@ if [ "$BRANCH" != "master" ]; then
   # Ship /rack-branchname
   cp $RACKBUILD build/${BASENAME}-${BRANCH}${SUFFIX}
   # Remove our artifact
-  rm $RACKBUILD
-elif [ "$os" == "windows" ]; then
-  cp $RACKBUILD $RACKBUILD${SUFFIX}
   rm $RACKBUILD
 fi

--- a/script/prep-travis-release.sh
+++ b/script/prep-travis-release.sh
@@ -63,38 +63,36 @@ case $arch in
   arm)
     # Note that we can never be 1:1 between `uname -m` and arm versions
     arch="armv${GOARM}"
-    SUFFIX="-${os}-${arch}"
     ;;
 esac
 
-if [[ "$os" == "Windows" && "$arch" == "amd64" ]]; then
+SUFFIX=""
+if [ "$os" == "Windows" ]; then
   SUFFIX=".exe"
-elif [[ "$os" == "Windows" && "$arch" != "amd64" ]]; then
-  SUFFIX="-${arch}.exe"
-elif [ "$arch" == "amd64" ]; then
-  # Assume 64 bit gets to be as is
-  SUFFIX="-${os}"
-else
-  SUFFIX="-${os}-${arch}"
 fi
 
-echo "Building for ${os}-${arch}"
+BASEDIR="build/${os}/${arch}"
+
+# Mirror the github layout for branches, tags, commits
+TREEDIR="${BASEDIR}/tree"
 
 mkdir -p build
-# Provide a commit hash version
-COMMIT=`git rev-parse HEAD 2> /dev/null`
-mkdir -p "build/commits/${COMMIT}"
+mkdir -p $BASEDIR
+mkdir -p $TREEDIR
 
 BASENAME="rack"
-RACKBUILD="build/${BASENAME}${SUFFIX}"
+
+# Base build not in build dir to prevent accidental upload with no prefix
+RACKBUILD="${BASENAME}${SUFFIX}"
 
 go build -o $RACKBUILD
 
-cp $RACKBUILD build/commits/${COMMIT}/${BASENAME}-${COMMIT}${SUFFIX}
+# Ship /tree/rack-branchname
+cp $RACKBUILD ${TREEDIR}/${BASENAME}-${BRANCH}${SUFFIX}
 
-if [ "$BRANCH" != "master" ]; then
-  # Ship /rack-branchname
-  cp $RACKBUILD build/${BASENAME}-${BRANCH}${SUFFIX}
-  # Remove our artifact
-  rm $RACKBUILD
+if [ "$BRANCH" == "master" ]; then
+  # Only when we're on master do we spit out the official ones.
+  cp $RACKBUILD ${BASEDIR}/${BASENAME}${SUFFIX}
 fi
+
+rm $RACKBUILD

--- a/script/prep-travis-release.sh
+++ b/script/prep-travis-release.sh
@@ -71,28 +71,39 @@ if [ "$os" == "Windows" ]; then
   SUFFIX=".exe"
 fi
 
-BASEDIR="build/${os}/${arch}"
+################################################################################
+# Set up the build and deploy layout
+################################################################################
 
+BUILDDIR="build"
+BASEDIR="${os}/${arch}"
 # Mirror the github layout for branches, tags, commits
-TREEDIR="${BASEDIR}/tree"
+TREEDIR="${os}/${arch}/tree"
 
-mkdir -p build
-mkdir -p $BASEDIR
-mkdir -p $TREEDIR
+CDN="https://ba7db30ac3f206168dbb-7f12cbe7f0a328a153fa25953cbec5f2.ssl.cf5.rackcdn.com"
+
+mkdir -p $BUILDDIR
+mkdir -p $BUILDDIR/$BASEDIR
+mkdir -p $BUILDDIR/$TREEDIR
 
 BASENAME="rack"
 
-# Base build not in build dir to prevent accidental upload with no prefix
+# Base build not in build dir to prevent accidental upload on failure
 RACKBUILD="${BASENAME}${SUFFIX}"
 
 go build -o $RACKBUILD
 
 # Ship /tree/rack-branchname
-cp $RACKBUILD ${TREEDIR}/${BASENAME}-${BRANCH}${SUFFIX}
+cp $RACKBUILD ${BUILDDIR}/${TREEDIR}/${BASENAME}-${BRANCH}${SUFFIX}
+echo "Fresh build for branch '${BRANCH}' at "
+echo "${CDN}/${TREEDIR}/${BASENAME}-${BRANCH}${SUFFIX}"
 
 if [ "$BRANCH" == "master" ]; then
   # Only when we're on master do we spit out the official ones.
-  cp $RACKBUILD ${BASEDIR}/${BASENAME}${SUFFIX}
+  cp $RACKBUILD ${BUILDDIR}/${BASEDIR}/${BASENAME}${SUFFIX}
+  echo "Get it while it's hot at"
+  echo "${CDN}/${BASEDIR}/${BASENAME}${SUFFIX}"
 fi
 
+# Clean up after build
 rm $RACKBUILD


### PR DESCRIPTION
Following feedback from @everett-toews and @carolynvs, I've set up builds a bit differently. This partially addresses #57 (`uname` for some). Default download for Windows is now `rack.exe` (no requiring an executable rename). They're now at 

```
/${os}/${arch}/rack(.exe)
```

Branches, tags, commits now (slightly) mirror the GitHub style layout:

```
/${os}/${arch}/tree/rack-${BRANCH}(.exe)
```

Note that the uname approach from #57 will not work for any ARM based installations, as they all report different versions of ARM even within e.g. ARMv7. `uname -m` returns `armv7l` on a Samsung Chromebook while Raspberry Pi will return `armv6l`.