### PR TITLE
Auth methods, credential caching, and error output handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,41 @@ go get github.com/jrperritt/rack
 go build -o $GOPATH/bin/rack
 ```
 
-Export the following environment variables:  
-RS_REGION_NAME (DFW, IAD, ORD, LON, SYD, HKG)  
-RS_USERNAME (Your Rackspace username)  
-RS_AUTH_URL (https://identity.api.rackspacecloud.com/v2.0)  
-RS_API_KEY (Your Rackspace API key)  
+## Setting Authentication Credentials
 
-You should then be able to run commands:
+### Environment Variables
+Export the following environment variables:  
+`RS_REGION_NAME` (DFW, IAD, ORD, LON, SYD, HKG)  
+`RS_USERNAME` (Your Rackspace username)  
+`RS_API_KEY` (Your Rackspace API key)  
+
+### Command-line
+You can set auth parameters on the command-line using global flags:
+`rack --username user1 --apikey 123456789 --region DFW servers instance list`
+
+### Config file
+You can create a config file in `~/.rack/config`:
+[DEFAULT]
+username=user1
+apikey=123456789
+region=DFW
+
+[PROFILE2]
+username=user2
+apikey=987654321
+region=IAD
+
+
+If you're using the default profile, you can call a command without additional flags:
 ```sh
 rack compute servers list
 ```
+
+However, if you'd like to use a different profile (such as PROFILE2 above):
+```sh
+rack --profile PROFILE2 compute servers list
+```
+
 
 ## Bash Completion
 Add the following line to your `.bashrc` file:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ You can set auth parameters on the command-line using global flags:
 `rack --username user1 --apikey 123456789 --region DFW servers instance list`
 
 ### Config file
-You can create a config file in `~/.rack/config`:
+You can create a config file in ` ~/.rack/config`:
+
+```
 [DEFAULT]
 username=user1
 apikey=123456789
@@ -37,7 +39,7 @@ region=DFW
 username=user2
 apikey=987654321
 region=IAD
-
+```
 
 If you're using the default profile, you can call a command without additional flags:
 ```sh

--- a/auth/cache.go
+++ b/auth/cache.go
@@ -86,8 +86,12 @@ func (cache *Cache) SetValue(cacheKey string, cacheValue *CacheItem) error {
 	if err != nil {
 		return err
 	}
-	// set cache value for cacheKey
-	cache.items[cacheKey] = *cacheValue
+	if cacheValue == nil {
+		delete(cache.items, cacheKey)
+	} else {
+		// set cache value for cacheKey
+		cache.items[cacheKey] = *cacheValue
+	}
 	filename, err := cacheFile()
 	if err != nil {
 		return err

--- a/auth/cache.go
+++ b/auth/cache.go
@@ -1,3 +1,78 @@
 package auth
 
-// logic for caching the authentication token goes here
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path"
+
+	"github.com/rackspace/gophercloud"
+)
+
+// Creds are values that are cached to prevent re-authenticating for
+// every CLI command.
+type Creds struct {
+	Ao     gophercloud.AuthOptions
+	Region string
+}
+
+// GetCacheValue returns the cached value for the given key if it exists. It
+func GetCacheValue(cacheKey string) (map[string]interface{}, error) {
+	dir, err := rackDir()
+	if err != nil {
+		return nil, fmt.Errorf("Error reading from cache: %s", err)
+	}
+	f := path.Join(dir, "cache")
+	cacheRaw, err := ioutil.ReadFile(f)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading from cache: %s", err)
+	}
+	var m map[string]map[string]interface{}
+	err = json.Unmarshal(cacheRaw, m)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading from cache: %s", err)
+	}
+	return m[cacheKey], nil
+}
+
+// GetCacheValueCreds returns the user's cached credentials.
+func GetCacheValueCreds(cacheKey string) (*Creds, error) {
+	m, err := GetCacheValue(cacheKey)
+	if err != nil {
+		return nil, err
+	}
+	if m != nil {
+		if raw := m["creds"]; raw != nil {
+			if cc, ok := raw.(Creds); ok {
+				return &cc, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// SetCacheValueCreds writes the user's current credentials to the cache.
+func SetCacheValueCreds(cacheKey, cacheValue *Creds) {
+
+}
+
+// GetCacheValueProviderClient returns the user's cached provider client.
+func GetCacheValueProviderClient(cacheKey string) (*gophercloud.ProviderClient, error) {
+	m, err := GetCacheValue(cacheKey)
+	if err != nil {
+		return nil, err
+	}
+	if m != nil {
+		if raw := m["pc"]; raw != nil {
+			if cc, ok := raw.(gophercloud.ProviderClient); ok {
+				return &cc, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// SetCacheValueProviderClient writes the user's current provider client to the cache.
+func SetCacheValueProviderClient(cacheKey, cacheValue *gophercloud.ProviderClient) {
+
+}

--- a/auth/cache.go
+++ b/auth/cache.go
@@ -79,8 +79,7 @@ func (cache *Cache) all() error {
 func (cache *Cache) Value(cacheKey string) (*CacheItem, error) {
 	err := cache.all()
 	if err != nil {
-		fmt.Printf("Error getting cache value: %s", err)
-		return nil, err
+		return nil, fmt.Errorf("Error getting cache value: %s", err)
 	}
 	creds := cache.items[cacheKey]
 	if creds.TokenID == "" {

--- a/auth/cache.go
+++ b/auth/cache.go
@@ -45,7 +45,8 @@ func cacheFile() (string, error) {
 		return filepath, nil
 	}
 	// create the cache file if it doesn't already exist
-	_, err = os.Create(filepath)
+	f, err := os.Create(filepath)
+	defer f.Close()
 	return filepath, err
 }
 

--- a/auth/clients.go
+++ b/auth/clients.go
@@ -18,7 +18,7 @@ func reauthFunc(pc *gophercloud.ProviderClient, ao gophercloud.AuthOptions) func
 }
 
 // NewClient creates and returns a Rackspace client for the given service.
-func NewClient(c *cli.Context, t string) (*gophercloud.ServiceClient, error) {
+func NewClient(c *cli.Context, serviceType string) (*gophercloud.ServiceClient, error) {
 	// get the user's authentication credentials
 	ao, region := Credentials(c)
 	// upper-case the region
@@ -31,7 +31,7 @@ func NewClient(c *cli.Context, t string) (*gophercloud.ServiceClient, error) {
 	}
 
 	// form the cache key
-	cacheKey := CacheKey(ao, region, t)
+	cacheKey := CacheKey(ao, region, serviceType)
 	// initialize cache
 	cache := &Cache{}
 	// get the value from the cache
@@ -56,7 +56,7 @@ func NewClient(c *cli.Context, t string) (*gophercloud.ServiceClient, error) {
 			return nil, fmt.Errorf("Error creating ProviderClient: %s\n", err)
 		}
 		var sc *gophercloud.ServiceClient
-		switch t {
+		switch serviceType {
 		case "compute":
 			sc, err = rackspace.NewComputeV2(pc, gophercloud.EndpointOpts{
 				Region: region,
@@ -77,7 +77,7 @@ func NewClient(c *cli.Context, t string) (*gophercloud.ServiceClient, error) {
 			return nil, fmt.Errorf("Error creating ServiceClient: %s\n", err)
 		}
 		if sc == nil {
-			return nil, fmt.Errorf("Unable to create service client: Unknown service type: %s", t)
+			return nil, fmt.Errorf("Unable to create service client: Unknown service type: %s", serviceType)
 		}
 		sc.UserAgent.Prepend("rack/" + util.Version)
 		return sc, nil

--- a/auth/clients.go
+++ b/auth/clients.go
@@ -2,73 +2,97 @@ package auth
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/codegangsta/cli"
+	"github.com/jrperritt/rack/util"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/rackspace"
 )
 
+// reauthFunc is what the ServiceClient uses to re-authenticate.
+func reauthFunc(pc *gophercloud.ProviderClient, ao gophercloud.AuthOptions) func() error {
+	return func() error {
+		return rackspace.AuthenticateV2(pc, ao)
+	}
+}
+
 // NewClient creates and returns a Rackspace client for the given service.
-func NewClient(c *cli.Context, t string) *gophercloud.ServiceClient {
-	ao, region := authMethod(c)
+func NewClient(c *cli.Context, t string) (*gophercloud.ServiceClient, error) {
+	// get the user's authentication credentials
+	ao, region := Credentials(c)
+	// upper-case the region
 	region = strings.ToUpper(region)
+	// allow Gophercloud to re-authenticate
 	ao.AllowReauth = true
+	// if the user didn't provide an auth URL, default to the Rackspace US endpoint
 	if ao.IdentityEndpoint == "" {
 		ao.IdentityEndpoint = rackspace.RackspaceUSIdentity
 	}
 
-	var pc *gophercloud.ProviderClient
-
-	cacheKey := fmt.Sprintf("%s,%s,%s,%s", ao.Username, ao.APIKey, ao.IdentityEndpoint, region)
-	cachedValue, err := GetCacheValue(cacheKey)
-	if err == nil {
-		if cachedAo, ok := cachedValue["ao"].(gophercloud.AuthOptions); ok && cachedAo == ao {
-			if cachedPc, ok := cachedValue["pc"].(gophercloud.ProviderClient); ok {
-				pc = &cachedPc
-			}
-		}
-	}
-
-	if pc == nil {
-		pc, err = rackspace.AuthenticatedClient(ao)
-		if err != nil {
-			fmt.Printf("Error creating ProviderClient: %s\n", err)
-			os.Exit(1)
-		}
-	}
-
 	var sc *gophercloud.ServiceClient
-	switch t {
-	case "compute":
-		sc, err = rackspace.NewComputeV2(pc, gophercloud.EndpointOpts{
-			Region: region,
-		})
-		break
-	case "blockstorage":
-		sc, err = rackspace.NewBlockStorageV1(pc, gophercloud.EndpointOpts{
-			Region: region,
-		})
-		break
-	case "networking":
-		sc, err = rackspace.NewNetworkV2(pc, gophercloud.EndpointOpts{
-			Region: region,
-		})
-		break
+
+	// form the cache key
+	cacheKey := CacheKey(ao, region, t)
+	// initialize cache
+	cache := &Cache{}
+	// get the value from the cache
+	creds, err := cache.Value(cacheKey)
+	// if there was an error accessing the cache or there was nothing in the cache,
+	// authenticate from scratch
+	if err != nil || creds == nil {
+		pc, err := rackspace.AuthenticatedClient(ao)
+		if err != nil {
+			return nil, fmt.Errorf("Error creating ProviderClient: %s\n", err)
+		}
+		switch t {
+		case "compute":
+			sc, err = rackspace.NewComputeV2(pc, gophercloud.EndpointOpts{
+				Region: region,
+			})
+			break
+		case "blockstorage":
+			sc, err = rackspace.NewBlockStorageV1(pc, gophercloud.EndpointOpts{
+				Region: region,
+			})
+			break
+		case "networking":
+			sc, err = rackspace.NewNetworkV2(pc, gophercloud.EndpointOpts{
+				Region: region,
+			})
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("Error creating ServiceClient: %s\n", err)
+		}
+	} else {
+		// we successfully retrieved a value from the cache
+		pc := &gophercloud.ProviderClient{
+			IdentityBase:     creds.IdentityBase,
+			IdentityEndpoint: creds.IdentityEndpoint,
+			TokenID:          creds.TokenID,
+			HTTPClient:       creds.HTTPClient,
+		}
+		pc.ReauthFunc = reauthFunc(pc, ao)
+		sc = &gophercloud.ServiceClient{
+			ProviderClient: pc,
+			Endpoint:       creds.ServiceEndpoint,
+		}
 	}
-	if err != nil {
-		fmt.Printf("Error creating ServiceClient (%s): %s\n", err, t)
-		os.Exit(1)
-	}
-	// sc.UserAgent.Prepend("rack/" + util.Version)
-	return sc
+
+	// set the user-agent
+	sc.UserAgent.Prepend("rack/" + util.Version)
+
+	return sc, nil
 }
 
-// authMethod determines the appropriate authentication method for the user.
-// It returns a gophercloud.AuthOptions object, the region, and the error.
+// Credentials determines the appropriate authentication method for the user.
+// It returns a gophercloud.AuthOptions object and a region.
 //
-func authMethod(c *cli.Context) (gophercloud.AuthOptions, string) {
+// It will use command-line authentication parameters if available, then it will
+// look for any unset parameters in the config file, and then finally in
+// environment variables.
+func Credentials(c *cli.Context) (gophercloud.AuthOptions, string) {
 	have := make(map[string]string)
 	need := map[string]string{
 		"username": "",
@@ -77,9 +101,18 @@ func authMethod(c *cli.Context) (gophercloud.AuthOptions, string) {
 		"region":   "",
 	}
 
+	// use command-line options if available
 	cliopts(c, have, need)
-	configfile(c, have, need)
-	envvars(have, need)
+	// are there any unset auth variables?
+	if len(need) != 0 {
+		// if so, look in config file
+		configfile(c, have, need)
+		// still unset auth variables?
+		if len(need) != 0 {
+			// if so, look in environment variables
+			envvars(have, need)
+		}
+	}
 
 	ao := gophercloud.AuthOptions{
 		Username:         have["username"],

--- a/auth/clients.go
+++ b/auth/clients.go
@@ -3,28 +3,42 @@ package auth
 import (
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/codegangsta/cli"
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/rackspace"
 )
 
 // NewClient creates and returns a Rackspace client for the given service.
-func NewClient(t string) *gophercloud.ServiceClient {
-	var err error
-	ao, region, err := authMethod()
-	if err != nil {
-		if err == rackspace.ErrNoAuthURL {
-			ao.IdentityEndpoint = rackspace.RackspaceUSIdentity
-		} else {
-			fmt.Printf("Error determining AuthOptions and/or region: %s\n", err)
+func NewClient(c *cli.Context, t string) *gophercloud.ServiceClient {
+	ao, region := authMethod(c)
+	region = strings.ToUpper(region)
+	ao.AllowReauth = true
+	if ao.IdentityEndpoint == "" {
+		ao.IdentityEndpoint = rackspace.RackspaceUSIdentity
+	}
+
+	var pc *gophercloud.ProviderClient
+
+	cacheKey := fmt.Sprintf("%s,%s,%s,%s", ao.Username, ao.APIKey, ao.IdentityEndpoint, region)
+	cachedValue, err := GetCacheValue(cacheKey)
+	if err == nil {
+		if cachedAo, ok := cachedValue["ao"].(gophercloud.AuthOptions); ok && cachedAo == ao {
+			if cachedPc, ok := cachedValue["pc"].(gophercloud.ProviderClient); ok {
+				pc = &cachedPc
+			}
+		}
+	}
+
+	if pc == nil {
+		pc, err = rackspace.AuthenticatedClient(ao)
+		if err != nil {
+			fmt.Printf("Error creating ProviderClient: %s\n", err)
 			os.Exit(1)
 		}
 	}
-	pc, err := rackspace.AuthenticatedClient(ao)
-	if err != nil {
-		fmt.Printf("Error creating ProviderClient: %s\n", err)
-		os.Exit(1)
-	}
+
 	var sc *gophercloud.ServiceClient
 	switch t {
 	case "compute":
@@ -54,6 +68,23 @@ func NewClient(t string) *gophercloud.ServiceClient {
 // authMethod determines the appropriate authentication method for the user.
 // It returns a gophercloud.AuthOptions object, the region, and the error.
 //
-func authMethod() (gophercloud.AuthOptions, string, error) {
-	return envvars()
+func authMethod(c *cli.Context) (gophercloud.AuthOptions, string) {
+	have := make(map[string]string)
+	need := map[string]string{
+		"username": "",
+		"apikey":   "",
+		"authurl":  "",
+		"region":   "",
+	}
+
+	cliopts(c, have, need)
+	configfile(c, have, need)
+	envvars(have, need)
+
+	ao := gophercloud.AuthOptions{
+		Username:         have["username"],
+		APIKey:           have["apikey"],
+		IdentityEndpoint: have["authurl"],
+	}
+	return ao, have["region"]
 }

--- a/auth/cliopts.go
+++ b/auth/cliopts.go
@@ -4,8 +4,8 @@ import "github.com/codegangsta/cli"
 
 func cliopts(c *cli.Context, have map[string]string, need map[string]string) {
 	for opt := range need {
-		if c.IsSet(opt) {
-			have[opt] = c.String(opt)
+		if c.GlobalIsSet(opt) {
+			have[opt] = c.GlobalString(opt)
 			delete(need, opt)
 		}
 	}

--- a/auth/cliopts.go
+++ b/auth/cliopts.go
@@ -1,3 +1,12 @@
 package auth
 
-// authentication method via command-line options goes here
+import "github.com/codegangsta/cli"
+
+func cliopts(c *cli.Context, have map[string]string, need map[string]string) {
+	for opt := range need {
+		if c.IsSet(opt) {
+			have[opt] = c.String(opt)
+			delete(need, opt)
+		}
+	}
+}

--- a/auth/configfile.go
+++ b/auth/configfile.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"fmt"
 	"path"
 
 	"github.com/codegangsta/cli"
@@ -12,13 +11,13 @@ import (
 func configfile(c *cli.Context, have map[string]string, need map[string]string) {
 	dir, err := util.RackDir()
 	if err != nil {
-		fmt.Fprint(c.App.Writer, err)
+		//fmt.Printf("Error reading config file: %s\n", err)
 		return
 	}
 	f := path.Join(dir, "config")
 	cfg, err := ini.Load(f)
 	if err != nil {
-		fmt.Printf("Error reading config file: %s\n", err)
+		//fmt.Printf("Error reading config file: %s\n", err)
 		return
 	}
 	cfg.BlockMode = false
@@ -28,7 +27,7 @@ func configfile(c *cli.Context, have map[string]string, need map[string]string) 
 	}
 	section, err := cfg.GetSection(profile)
 	if err != nil {
-		fmt.Printf("Error reading config file: %s\n", err)
+		//fmt.Printf("Error reading config file: %s\n", err)
 		return
 	}
 

--- a/auth/configfile.go
+++ b/auth/configfile.go
@@ -1,3 +1,34 @@
 package auth
 
-// authentication method via config/ini file goes here
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/codegangsta/cli"
+	"gopkg.in/ini.v1"
+)
+
+func configfile(c *cli.Context, have map[string]string, need map[string]string) {
+	dir, err := rackDir()
+	if err != nil {
+		fmt.Fprint(c.App.Writer, err)
+		return
+	}
+	f := path.Join(dir, "creds")
+	cfg, err := ini.Load(f)
+	fmt.Printf("cfg: %+v\n", cfg)
+}
+
+func rackDir() (string, error) {
+	homeDir := os.Getenv("HOME") // *nix
+	if homeDir == "" {           // Windows
+		homeDir = os.Getenv("USERPROFILE")
+	}
+	if homeDir == "" {
+		return "", errors.New("User home directory not found.")
+	}
+
+	return path.Join(homeDir, ".rack"), nil
+}

--- a/auth/envvars.go
+++ b/auth/envvars.go
@@ -3,13 +3,19 @@ package auth
 import (
 	"os"
 	"strings"
-
-	"github.com/rackspace/gophercloud"
-	"github.com/rackspace/gophercloud/rackspace"
 )
 
-func envvars() (gophercloud.AuthOptions, string, error) {
-	ao, err := rackspace.AuthOptionsFromEnv()
-	region := strings.ToUpper(os.Getenv("RS_REGION_NAME"))
-	return ao, region, err
+func envvars(have map[string]string, need map[string]string) {
+	vars := map[string]string{
+		"username": "RS_USERNAME",
+		"apikey":   "RS_API_KEY",
+		"authurl":  "RS_AUTH_URL",
+		"region":   "RS_REGION_NAME",
+	}
+	for opt := range need {
+		if v := os.Getenv(strings.ToUpper(vars[opt])); v != "" {
+			have[opt] = v
+			delete(need, opt)
+		}
+	}
 }

--- a/auth/envvars.go
+++ b/auth/envvars.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"os"
+	"strings"
 
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/rackspace"
@@ -9,6 +10,6 @@ import (
 
 func envvars() (gophercloud.AuthOptions, string, error) {
 	ao, err := rackspace.AuthOptionsFromEnv()
-	region := os.Getenv("RS_REGION_NAME")
+	region := strings.ToUpper(os.Getenv("RS_REGION_NAME"))
 	return ao, region, err
 }

--- a/globalflags.go
+++ b/globalflags.go
@@ -25,11 +25,39 @@ func outputFlags() []cli.Flag {
 	}
 }
 
+// authFlags are global flags (i.e. flags that all commands can use) that let
+// users specify authentication parameters.
+func authFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:  "username",
+			Usage: "The username with which to authenticate.",
+		},
+		cli.StringFlag{
+			Name:  "apikey",
+			Usage: "The API key with which to authenticate.",
+		},
+		cli.StringFlag{
+			Name:  "authurl",
+			Usage: "The endpoint to which authenticate.",
+		},
+		cli.StringFlag{
+			Name:  "region",
+			Usage: "The region to which authenticate.",
+		},
+		cli.StringFlag{
+			Name:  "profile",
+			Usage: "The config file profile to use for authentication.",
+		},
+	}
+}
+
 // globalFlags returns the flags that can be used after `rack` in a command, such as
-// `--json`, `--csv`, and `--table`.
+// output flags and authentication flags.
 func globalFlags() []cli.Flag {
-	outputFlags := outputFlags()
-	return outputFlags
+	gFlags := outputFlags()
+	gFlags = append(gFlags, authFlags()...)
+	return gFlags
 }
 
 // completeGlobals returns the options for completing global flags.

--- a/globalflags.go
+++ b/globalflags.go
@@ -49,6 +49,10 @@ func authFlags() []cli.Flag {
 			Name:  "profile",
 			Usage: "The config file profile to use for authentication.",
 		},
+		cli.BoolFlag{
+			Name:  "no-cache",
+			Usage: "Don't get or set authentication credentials in the rack cache.",
+		},
 	}
 }
 

--- a/output/output.go
+++ b/output/output.go
@@ -100,9 +100,12 @@ func Print(o *Params) {
 	// if o.ServiceClient is nil, the HTTP request for the command didn't get sent.
 	// don't set cache if the `no-cache` flag is provided
 	if o.ServiceClient != nil && !c.GlobalIsSet("no-cache") {
-		newCacheValue := &auth.CacheItem{
-			TokenID:         serviceClient.TokenID,
-			ServiceEndpoint: serviceClient.Endpoint,
+		var newCacheValue *auth.CacheItem
+		if o.Err == nil {
+			newCacheValue = &auth.CacheItem{
+				TokenID:         serviceClient.TokenID,
+				ServiceEndpoint: serviceClient.Endpoint,
+			}
 		}
 		// get auth credentials
 		ao, region := auth.Credentials(c)

--- a/output/output.go
+++ b/output/output.go
@@ -97,8 +97,9 @@ type Params struct {
 func Print(o *Params) {
 	c := o.Context
 	serviceClient := o.ServiceClient
-	// if o.ServiceClient is nil, the HTTP request for the command didn't get sent
-	if o.ServiceClient != nil {
+	// if o.ServiceClient is nil, the HTTP request for the command didn't get sent.
+	// don't set cache if the `no-cache` flag is provided
+	if o.ServiceClient != nil && !c.GlobalIsSet("no-cache") {
 		newCacheValue := &auth.CacheItem{
 			TokenID:         serviceClient.TokenID,
 			ServiceEndpoint: serviceClient.Endpoint,

--- a/output/output.go
+++ b/output/output.go
@@ -100,11 +100,8 @@ func Print(o *Params) {
 	// if o.ServiceClient is nil, the HTTP request for the command didn't get sent
 	if o.ServiceClient != nil {
 		newCacheValue := &auth.CacheItem{
-			IdentityBase:     serviceClient.IdentityBase,
-			IdentityEndpoint: serviceClient.IdentityEndpoint,
-			TokenID:          serviceClient.TokenID,
-			HTTPClient:       serviceClient.HTTPClient,
-			ServiceEndpoint:  serviceClient.Endpoint,
+			TokenID:         serviceClient.TokenID,
+			ServiceEndpoint: serviceClient.Endpoint,
 		}
 		// get auth credentials
 		ao, region := auth.Credentials(c)

--- a/output/output.go
+++ b/output/output.go
@@ -5,8 +5,26 @@ import (
 	"strings"
 
 	"github.com/codegangsta/cli"
+	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/util"
+	"github.com/rackspace/gophercloud"
 )
+
+// Params are the variables that the `Print` function needs to finish processing
+// output from the command:
+// Context: used for getting the output format (json, csv, table) and fields to return,
+// F: a pointer to a function that return the data to be returned,
+// Keys: the available fields to return for the command,
+// ServiceClient: used for caching a user's authentication credentials,
+// Err: the error encountered while running the command, if any.
+type Params struct {
+	Context           *cli.Context
+	F                 *func() interface{}
+	Keys              []string
+	ServiceClient     *gophercloud.ServiceClient
+	ServiceClientType string
+	Err               error
+}
 
 // Print prints the results of the CLI command. This function is designed to centralize
 // printing command output and to accomodate the way the Rackspace API is designed.
@@ -76,9 +94,41 @@ import (
 //
 // keys) a slice of strings: this slice contains the header values to print out for
 // 		the tabular and csv formats.
-func Print(c *cli.Context, f *func() interface{}, keys []string) {
-	i := (*f)()
-	keys = limitFields(c, keys)
+func Print(o *Params) {
+	c := o.Context
+	serviceClient := o.ServiceClient
+	// if o.ServiceClient is nil, the HTTP request for the command didn't get sent
+	if o.ServiceClient != nil {
+		newCacheValue := &auth.CacheItem{
+			IdentityBase:     serviceClient.IdentityBase,
+			IdentityEndpoint: serviceClient.IdentityEndpoint,
+			TokenID:          serviceClient.TokenID,
+			HTTPClient:       serviceClient.HTTPClient,
+			ServiceEndpoint:  serviceClient.Endpoint,
+		}
+		// get auth credentials
+		ao, region := auth.Credentials(c)
+		// form the cache key
+		cacheKey := auth.CacheKey(ao, region, o.ServiceClientType)
+		// initialize the cache
+		cache := &auth.Cache{}
+		// set the cache value to the current values
+		_ = cache.SetValue(cacheKey, newCacheValue)
+	}
+
+	// limit the returned fields if any were given in the `fields` flag
+	keys := limitFields(c, o.Keys)
+
+	var i interface{}
+	// if an error occurred during the command, only return the error message
+	if o.Err != nil {
+		keys = []string{"error"}
+		i = map[string]interface{}{"error": o.Err.Error()}
+		// otherwise, get the data to return
+	} else {
+		i = (*o.F)()
+	}
+
 	w := c.App.Writer
 	if c.GlobalIsSet("json") {
 		switch i.(type) {

--- a/serverscommands/flavorcommands/commands.go
+++ b/serverscommands/flavorcommands/commands.go
@@ -3,6 +3,7 @@ package flavorcommands
 import "github.com/codegangsta/cli"
 
 var commandPrefix = "servers flavor"
+var serviceClientType = "compute"
 
 // Get returns all the commands allowed for a `compute flavors` request.
 func Get() []cli.Command {

--- a/serverscommands/flavorcommands/get.go
+++ b/serverscommands/flavorcommands/get.go
@@ -2,19 +2,19 @@ package flavorcommands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/codegangsta/cli"
 	"github.com/fatih/structs"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
+	osFlavors "github.com/rackspace/gophercloud/openstack/compute/v2/flavors"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/flavors"
 )
 
 var get = cli.Command{
 	Name:        "get",
-	Usage:       fmt.Sprintf("%s %s get <flavorID> [flags]", util.Name, commandPrefix),
+	Usage:       util.Usage(commandPrefix, "get", util.IDOrNameUsage("flavor")),
 	Description: "Retreives a flavor",
 	Action:      commandGet,
 	Flags:       util.CommandFlags(flagsGet, keysGet),
@@ -24,23 +24,49 @@ var get = cli.Command{
 }
 
 func flagsGet() []cli.Flag {
-	return []cli.Flag{}
+	return util.IDAndNameFlags
 }
 
 var keysGet = []string{"ID", "Name", "Disk", "RAM", "RxTxFactor", "Swap", "VCPUs"}
 
 func commandGet(c *cli.Context) {
-	util.CheckArgNum(c, 1)
-	flavorID := c.Args()[0]
-	client := auth.NewClient("compute")
-	o, err := flavors.Get(client, flavorID).Extract()
+	var err error
+	outputParams := &output.Params{
+		Context: c,
+		Keys:    keysGet,
+	}
+	err = util.CheckArgNum(c, 0)
 	if err != nil {
-		fmt.Printf("Error retreiving flavor [%s]: %s\n", flavorID, err)
-		os.Exit(1)
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+
+	outputParams.ServiceClientType = serviceClientType
+	client, err := auth.NewClient(c, outputParams.ServiceClientType)
+	if err != nil {
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+
+	flavorID, err := util.IDOrName(c, client, osFlavors.IDFromName)
+	if err != nil {
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+	o, err := flavors.Get(client, flavorID).Extract()
+	outputParams.ServiceClient = client
+	if err != nil {
+		outputParams.Err = fmt.Errorf("Error retrieving flavor [%s]: %s\n", flavorID, err)
+		output.Print(outputParams)
+		return
 	}
 
 	f := func() interface{} {
 		return structs.Map(o)
 	}
-	output.Print(c, &f, keysGet)
+	outputParams.F = &f
+	output.Print(outputParams)
 }

--- a/serverscommands/imagecommands/commands.go
+++ b/serverscommands/imagecommands/commands.go
@@ -3,6 +3,7 @@ package imagecommands
 import "github.com/codegangsta/cli"
 
 var commandPrefix = "servers image"
+var serviceClientType = "compute"
 
 // Get returns all the commands allowed for a `compute images` request.
 func Get() []cli.Command {

--- a/serverscommands/imagecommands/get.go
+++ b/serverscommands/imagecommands/get.go
@@ -2,19 +2,19 @@ package imagecommands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/codegangsta/cli"
 	"github.com/fatih/structs"
+	"github.com/jrperritt/gophercloud/rackspace/compute/v2/images"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
-	"github.com/rackspace/gophercloud/rackspace/compute/v2/images"
+	osImages "github.com/rackspace/gophercloud/openstack/compute/v2/images"
 )
 
 var get = cli.Command{
 	Name:        "get",
-	Usage:       fmt.Sprintf("%s %s get <imageID> [flags]", util.Name, commandPrefix),
+	Usage:       util.Usage(commandPrefix, "get", util.IDOrNameUsage("image")),
 	Description: "Retreives an image",
 	Action:      commandGet,
 	Flags:       util.CommandFlags(flagsGet, keysGet),
@@ -24,22 +24,49 @@ var get = cli.Command{
 }
 
 func flagsGet() []cli.Flag {
-	return []cli.Flag{}
+	return util.IDAndNameFlags
 }
 
 var keysGet = []string{"ID", "Name", "Status", "Progress", "MinDisk", "MinRAM", "Created", "Updated"}
 
 func commandGet(c *cli.Context) {
-	util.CheckArgNum(c, 1)
-	imageID := c.Args()[0]
-	client := auth.NewClient("compute")
-	o, err := images.Get(client, imageID).Extract()
-	if err != nil {
-		fmt.Printf("Error retreiving image [%s]: %s\n", imageID, err)
-		os.Exit(1)
+	var err error
+	outputParams := &output.Params{
+		Context: c,
+		Keys:    keysGet,
 	}
+	err = util.CheckArgNum(c, 0)
+	if err != nil {
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+
+	outputParams.ServiceClientType = serviceClientType
+	client, err := auth.NewClient(c, outputParams.ServiceClientType)
+	if err != nil {
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+
+	imageID, err := util.IDOrName(c, client, osImages.IDFromName)
+	if err != nil {
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+	o, err := images.Get(client, imageID).Extract()
+	outputParams.ServiceClient = client
+	if err != nil {
+		outputParams.Err = fmt.Errorf("Error retrieving image [%s]: %s\n", imageID, err)
+		output.Print(outputParams)
+		return
+	}
+
 	f := func() interface{} {
 		return structs.Map(o)
 	}
-	output.Print(c, &f, keysGet)
+	outputParams.F = &f
+	output.Print(outputParams)
 }

--- a/serverscommands/instancecommands/commands.go
+++ b/serverscommands/instancecommands/commands.go
@@ -3,6 +3,7 @@ package instancecommands
 import "github.com/codegangsta/cli"
 
 var commandPrefix = "servers instance"
+var serviceClientType = "compute"
 
 // Get returns all the commands allowed for a `servers instance` request.
 func Get() []cli.Command {

--- a/serverscommands/instancecommands/common.go
+++ b/serverscommands/instancecommands/common.go
@@ -1,48 +1,9 @@
 package instancecommands
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/codegangsta/cli"
 	"github.com/fatih/structs"
-	"github.com/jrperritt/rack/util"
-	"github.com/rackspace/gophercloud"
 	osServers "github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 )
-
-func idOrName(c *cli.Context, client *gophercloud.ServiceClient) string {
-	var err error
-	var serverID string
-	if c.IsSet("id") {
-		serverID = c.String("id")
-	} else if c.IsSet("name") {
-		serverName := c.String("name")
-		serverID, err = osServers.IDFromName(client, serverName)
-		if err != nil {
-			fmt.Printf("Error converting server name [%s] to ID: %s\n", serverName, err)
-			os.Exit(1)
-		}
-	} else {
-		util.PrintError(c, util.ErrMissingFlag{
-			Msg: "One of either --id or --name must be provided.",
-		})
-	}
-	return serverID
-}
-
-var idAndNameFlags = []cli.Flag{
-	cli.StringFlag{
-		Name:  "id",
-		Usage: "[optional; required if 'name' is not provided] The ID of the resource",
-	},
-	cli.StringFlag{
-		Name:  "name",
-		Usage: "[optional; required if 'id' is not provided] The name of the resource",
-	},
-}
-
-var idOrNameUsage = "[--id <serverID> | --name <serverName>]"
 
 func serverSingle(rawServer interface{}) map[string]interface{} {
 	server, ok := rawServer.(*osServers.Server)

--- a/serverscommands/instancecommands/delete.go
+++ b/serverscommands/instancecommands/delete.go
@@ -2,18 +2,19 @@ package instancecommands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/auth"
+	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
 	"github.com/rackspace/gophercloud/openstack/compute/v2/servers"
+	osServers "github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 )
 
 // delete is a reserved word in Go.
 var remove = cli.Command{
 	Name:        "delete",
-	Usage:       fmt.Sprintf("%s %s delete %s [optional flags]", util.Name, commandPrefix, idOrNameUsage),
+	Usage:       util.Usage(commandPrefix, "delete", util.IDOrNameUsage("instance")),
 	Description: "Deletes an existing server",
 	Action:      commandDelete,
 	Flags:       util.CommandFlags(flagsDelete, keysDelete),
@@ -23,18 +24,54 @@ var remove = cli.Command{
 }
 
 func flagsDelete() []cli.Flag {
-	return idAndNameFlags
+	return util.IDAndNameFlags
 }
 
 var keysDelete = []string{}
 
 func commandDelete(c *cli.Context) {
-	util.CheckArgNum(c, 0)
-	client := auth.NewClient("compute")
-	serverID := idOrName(c, client)
-	err := servers.Delete(client, serverID).ExtractErr()
-	if err != nil {
-		fmt.Printf("Error deleting server (%s): %s\n", serverID, err)
-		os.Exit(1)
+	var err error
+	outputParams := &output.Params{
+		Context: c,
+		Keys:    keysDelete,
 	}
+	err = util.CheckArgNum(c, 0)
+	if err != nil {
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+	err = util.CheckFlagsSet(c, []string{"name"})
+	if err != nil {
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+
+	outputParams.ServiceClientType = serviceClientType
+	client, err := auth.NewClient(c, outputParams.ServiceClientType)
+	if err != nil {
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+
+	serverID, err := util.IDOrName(c, client, osServers.IDFromName)
+	if err != nil {
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+	err = servers.Delete(client, serverID).ExtractErr()
+	outputParams.ServiceClient = client
+	if err != nil {
+		outputParams.Err = fmt.Errorf("Error deleting server (%s): %s\n", serverID, err)
+		output.Print(outputParams)
+		return
+	}
+	f := func() interface{} {
+		return fmt.Sprintf("Successfully deleted instance [%s]", serverID)
+	}
+	outputParams.F = &f
+	output.Print(outputParams)
 }

--- a/serverscommands/instancecommands/get.go
+++ b/serverscommands/instancecommands/get.go
@@ -2,18 +2,18 @@ package instancecommands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
+	osServers "github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
 )
 
 var get = cli.Command{
 	Name:        "get",
-	Usage:       fmt.Sprintf("%s %s get %s [optional flags]", util.Name, commandPrefix, idOrNameUsage),
+	Usage:       util.Usage(commandPrefix, "get", util.IDOrNameUsage("instance")),
 	Description: "Retrieves an existing server",
 	Action:      commandGet,
 	Flags:       util.CommandFlags(flagsGet, keysGet),
@@ -23,23 +23,57 @@ var get = cli.Command{
 }
 
 func flagsGet() []cli.Flag {
-	return idAndNameFlags
+	return util.IDAndNameFlags
 }
 
 var keysGet = []string{"ID", "Name", "Status", "Created", "Updated", "Image", "Flavor", "Public IPv4", "Public IPv6", "Private IPv4", "KeyName"}
 
 func commandGet(c *cli.Context) {
-	util.CheckArgNum(c, 0)
-	client := auth.NewClient("compute")
-	serverID := idOrName(c, client)
-	o, err := servers.Get(client, serverID).Extract()
+	var err error
+	// initialize parameters for processing the output
+	outputParams := &output.Params{
+		Context: c,
+		Keys:    keysGet,
+	}
+	// make sure no arguments are passed
+	err = util.CheckArgNum(c, 0)
+	// if arguments were passed, return early with error message
 	if err != nil {
-		fmt.Printf("Error retrieving server (%s): %s\n", serverID, err)
-		os.Exit(1)
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+
+	// set the type of the service client. this is used in `Print` to form the
+	// cache key
+	outputParams.ServiceClientType = serviceClientType
+	client, err := auth.NewClient(c, outputParams.ServiceClientType)
+	if err != nil {
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+
+	// check if the user provided an ID or a name for the instance
+	serverID, err := util.IDOrName(c, client, osServers.IDFromName)
+	if err != nil {
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+	o, err := servers.Get(client, serverID).Extract()
+	// set the service client on outputParams. this value will contain the new
+	// (and valid) token if the client had to re-authenticate
+	outputParams.ServiceClient = client
+	if err != nil {
+		outputParams.Err = fmt.Errorf("Error retrieving server (%s): %s\n", serverID, err)
+		output.Print(outputParams)
+		return
 	}
 
 	f := func() interface{} {
 		return serverSingle(o)
 	}
-	output.Print(c, &f, keysGet)
+	outputParams.F = &f
+	output.Print(outputParams)
 }

--- a/serverscommands/instancecommands/resize.go
+++ b/serverscommands/instancecommands/resize.go
@@ -15,7 +15,7 @@ import (
 var resize = cli.Command{
 	Name:        "resize",
 	Usage:       util.Usage(commandPrefix, "resize", strings.Join([]string{util.IDOrNameUsage("instance"), "--flavorID <flavorID>"}, " ")),
-	Description: "Rebuilds an existing server",
+	Description: "Resizes an existing server",
 	Action:      commandResize,
 	Flags:       util.CommandFlags(flagsResize, keysResize),
 	BashComplete: func(c *cli.Context) {

--- a/serverscommands/instancecommands/resize.go
+++ b/serverscommands/instancecommands/resize.go
@@ -2,10 +2,11 @@ package instancecommands
 
 import (
 	"fmt"
-	"os"
+	"strings"
 
 	"github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/auth"
+	"github.com/jrperritt/rack/output"
 	"github.com/jrperritt/rack/util"
 	osServers "github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
@@ -13,7 +14,7 @@ import (
 
 var resize = cli.Command{
 	Name:        "resize",
-	Usage:       fmt.Sprintf("%s %s resize %s [--flavorID <flavorID>] [optional flags]", util.Name, commandPrefix, idOrNameUsage),
+	Usage:       util.Usage(commandPrefix, "resize", strings.Join([]string{util.IDOrNameUsage("instance"), "--flavorID <flavorID>"}, " ")),
 	Description: "Rebuilds an existing server",
 	Action:      commandResize,
 	Flags:       util.CommandFlags(flagsResize, keysResize),
@@ -29,26 +30,60 @@ func flagsResize() []cli.Flag {
 			Usage: "[required] The ID of the flavor that the resized server should have.",
 		},
 	}
-	return append(cf, idAndNameFlags...)
+	return append(cf, util.IDAndNameFlags...)
 }
 
 var keysResize = []string{}
 
 func commandResize(c *cli.Context) {
-	util.CheckArgNum(c, 0)
-	if !c.IsSet("flavorID") {
-		util.PrintError(c, util.ErrMissingFlag{
-			Msg: "--flavorID is required.",
-		})
+	var err error
+	outputParams := &output.Params{
+		Context: c,
+		Keys:    keysResize,
 	}
-	client := auth.NewClient("compute")
-	serverID := idOrName(c, client)
-	opts := osServers.ResizeOpts{
-		FlavorRef: c.String("flavorID"),
-	}
-	err := servers.Resize(client, serverID, opts).ExtractErr()
+	err = util.CheckArgNum(c, 0)
 	if err != nil {
-		fmt.Printf("Error resizing server (%s): %s\n", serverID, err)
-		os.Exit(1)
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
 	}
+
+	err = util.CheckFlagsSet(c, []string{"flavorID"})
+	if err != nil {
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+
+	outputParams.ServiceClientType = serviceClientType
+	client, err := auth.NewClient(c, outputParams.ServiceClientType)
+	if err != nil {
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+
+	serverID, err := util.IDOrName(c, client, osServers.IDFromName)
+	if err != nil {
+		outputParams.Err = err
+		output.Print(outputParams)
+		return
+	}
+
+	flavorID := c.String("flavorID")
+	opts := osServers.ResizeOpts{
+		FlavorRef: flavorID,
+	}
+	err = servers.Resize(client, serverID, opts).ExtractErr()
+	outputParams.ServiceClient = client
+	if err != nil {
+		outputParams.Err = fmt.Errorf("Error resizing instance [%s] to flavor [%s]: %s\n", serverID, flavorID, err)
+		output.Print(outputParams)
+		return
+	}
+	f := func() interface{} {
+		return fmt.Sprintf("Successfully resized instance [%s] to flavor [%s]", serverID, flavorID)
+	}
+	outputParams.F = &f
+	output.Print(outputParams)
 }

--- a/serverscommands/keypaircommands/commands.go
+++ b/serverscommands/keypaircommands/commands.go
@@ -3,6 +3,7 @@ package keypaircommands
 import "github.com/codegangsta/cli"
 
 var commandPrefix = "servers keypair"
+var serviceClientType = "compute"
 
 // Get returns all the commands allowed for a `compute keypairs` request.
 func Get() []cli.Command {

--- a/util/commandflags.go
+++ b/util/commandflags.go
@@ -46,17 +46,17 @@ func CompleteFlags(flags []cli.Flag) {
 }
 
 // CheckKVFlag is a function used for verifying the format of a key-value flag.
-func CheckKVFlag(c *cli.Context, flagName string) map[string]string {
+func CheckKVFlag(c *cli.Context, flagName string) (map[string]string, error) {
 	kv := make(map[string]string)
 	kvStrings := strings.Split(c.String(flagName), ",")
 	for _, kvString := range kvStrings {
 		temp := strings.Split(kvString, "=")
 		if len(temp) != 2 {
-			PrintError(c, ErrFlagFormatting{
+			return nil, Error(c, ErrFlagFormatting{
 				Msg: fmt.Sprintf("Expected key1=value1,key2=value2 format but got %s for --%s.\n", kvString, flagName),
 			})
 		}
 		kv[temp[0]] = temp[1]
 	}
-	return kv
+	return kv, nil
 }

--- a/util/errors.go
+++ b/util/errors.go
@@ -2,20 +2,17 @@ package util
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/codegangsta/cli"
 )
 
-// PrintError is used for printing information when an error is encountered.
-func PrintError(c *cli.Context, err error) {
-	w := c.App.Writer
-	switch err.(type) {
-	case ErrMissingFlag, ErrFlagFormatting:
-		fmt.Fprintf(w, "%s", err.Error())
-		fmt.Fprintf(w, "Usage: %s\n", c.Command.Usage)
+// Error is used for printing information when an error is encountered.
+func Error(c *cli.Context, e error) error {
+	switch e.(type) {
+	case ErrMissingFlag, ErrFlagFormatting, ErrArgs:
+		return fmt.Errorf("%s\nUsage: %s\n", e.Error(), c.Command.Usage)
 	}
-	os.Exit(1)
+	return fmt.Errorf("%s\n", e)
 }
 
 // ErrMissingFlagPrefix is the prefix for when a required flag is missing.
@@ -40,4 +37,14 @@ type ErrFlagFormatting struct {
 
 func (e ErrFlagFormatting) Error() string {
 	return fmt.Sprintf("%s %s\n", ErrFlagFormattingPrefix, e.Msg)
+}
+
+var ErrArgsFlagPrefix = "Argument error:"
+
+type ErrArgs struct {
+	Msg string
+}
+
+func (e ErrArgs) Error() string {
+	return fmt.Sprintf("%s %s\n", ErrArgsFlagPrefix, e.Msg)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -18,7 +18,7 @@ var Version = "0.0.0-dev"
 
 // Usage return a string that specifies how to call a particular command.
 func Usage(commandPrefix, action, mandatoryFlags string) string {
-	return fmt.Sprintf("%s [globals] %s %s %s [flags]", name, commandPrefix, action, mandatoryFlags)
+	return fmt.Sprintf("%s [GLOBALS] %s %s %s [OPTIONS]", name, commandPrefix, action, mandatoryFlags)
 }
 
 // Contains checks whether a given string is in a provided slice of strings.

--- a/util/util.go
+++ b/util/util.go
@@ -41,8 +41,9 @@ func RackDir() (string, error) {
 	if homeDir == "" {
 		return "", errors.New("User home directory not found.")
 	}
-
-	return path.Join(homeDir, ".rack"), nil
+	dirpath := path.Join(homeDir, ".rack")
+	err := os.MkdirAll(dirpath, 0644)
+	return dirpath, err
 }
 
 // CheckArgNum checks that the provided number of arguments has the same

--- a/util/util.go
+++ b/util/util.go
@@ -1,17 +1,25 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/codegangsta/cli"
+	"github.com/rackspace/gophercloud"
 )
 
 // Name is the name of the CLI
-var Name = "rack"
+var name = "rack"
 
 // Version is the current CLI version
-var Version = "0.1"
+var Version = "0.0.0-dev"
+
+// Usage return a string that specifies how to call a particular command.
+func Usage(commandPrefix, action, mandatoryFlags string) string {
+	return fmt.Sprintf("%s [globals] %s %s %s [flags]", name, commandPrefix, action, mandatoryFlags)
+}
 
 // Contains checks whether a given string is in a provided slice of strings.
 func Contains(s []string, e string) bool {
@@ -23,12 +31,75 @@ func Contains(s []string, e string) bool {
 	return false
 }
 
+// RackDir returns the location of the `rack` directory. This directory is for
+// storing `rack`-specific information such as the cache or a config file.
+func RackDir() (string, error) {
+	homeDir := os.Getenv("HOME") // *nix
+	if homeDir == "" {           // Windows
+		homeDir = os.Getenv("USERPROFILE")
+	}
+	if homeDir == "" {
+		return "", errors.New("User home directory not found.")
+	}
+
+	return path.Join(homeDir, ".rack"), nil
+}
+
 // CheckArgNum checks that the provided number of arguments has the same
 // cardinality as the expected number of arguments.
-func CheckArgNum(c *cli.Context, expected int) {
+func CheckArgNum(c *cli.Context, expected int) error {
 	argsLen := len(c.Args())
 	if argsLen != expected {
-		fmt.Printf("Expected %d args but got %d\nUsage: %s\n", expected, argsLen, c.Command.Usage)
-		os.Exit(1)
+		return fmt.Errorf("Expected %d args but got %d\nUsage: %s", expected, argsLen, c.Command.Usage)
 	}
+	return nil
+}
+
+// CheckFlagsSet checks that the given flag names are set for the command.
+func CheckFlagsSet(c *cli.Context, flagNames []string) error {
+	for _, flagName := range flagNames {
+		if !c.IsSet(flagName) {
+			return Error(c, ErrMissingFlag{
+				Msg: fmt.Sprintf("--%s is required.", flagName),
+			})
+		}
+	}
+	return nil
+}
+
+// IDOrName is a function for retrieving a resources unique identifier based on
+// whether he or she passed an `id` or a `name` flag.
+func IDOrName(c *cli.Context, client *gophercloud.ServiceClient, idFromName func(*gophercloud.ServiceClient, string) (string, error)) (string, error) {
+	if c.IsSet("id") {
+		return c.String("id"), nil
+	} else if c.IsSet("name") {
+		name := c.String("name")
+		id, err := idFromName(client, name)
+		if err != nil {
+			return "", fmt.Errorf("Error converting name [%s] to ID: %s", name, err)
+		}
+		return id, nil
+	} else {
+		return "", Error(c, ErrMissingFlag{
+			Msg: "One of either --id or --name must be provided.",
+		})
+	}
+}
+
+// IDAndNameFlags are flags for commands that allow either an ID or a name.
+var IDAndNameFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:  "id",
+		Usage: "[optional; required if 'name' is not provided] The ID of the resource",
+	},
+	cli.StringFlag{
+		Name:  "name",
+		Usage: "[optional; required if 'id' is not provided] The name of the resource",
+	},
+}
+
+// IDOrNameUsage returns flag usage information for resources that allow either
+// an ID or a name.
+func IDOrNameUsage(resource string) string {
+	return fmt.Sprintf("[--id <%sID> | --name <%sName>]", resource, resource)
 }


### PR DESCRIPTION
This PR has a few things that blended into one another, which is why they're all here:
- config file and command-line authentication methods
- caching user authentication credentials
- consistency for output (namely, when an error was encountered, it was being printed and then the program would exit. now the errors are returned in the user-specified format)