### PR TITLE
Trigger the docs build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
 script:
 - go build -v ./...
 before_deploy:
+- curl -X POST http://readthedocs.org/build/rackspace-cli
 - "./script/prep-travis-release.sh"
 - cd build
 deploy:


### PR DESCRIPTION
Triggers the docs build before binaries are deployed.

Added according to @jnoller's suggestion.