### PR TITLE
Streamable

### DIFF
--- a/docs/services/files.rst
+++ b/docs/services/files.rst
@@ -65,7 +65,7 @@ Usage::
 
     rack files object upload --container <containerName> --name <objectName> --content <contentToUpload> [optional flags]
     rack files object upload --container <containerName> --name <objectName> --file <fileToUpload> [optional flags]
-    echo fileToUpload.txt | rack files object upload --container <containerName> --name <objectName> --stdin file [optional flags]
+    cat fileToUpload.txt | rack files object upload --container <containerName> --name <objectName> --stdin content [optional flags]
 
 ``download``
 ^^^^^^^^

--- a/output/csv.go
+++ b/output/csv.go
@@ -6,28 +6,6 @@ import (
 	"io"
 )
 
-func metadataCSV(writer io.Writer, m map[string]interface{}, keys []string) {
-	w := csv.NewWriter(writer)
-	w.Write([]string{"PROPERTY", "VALUE"})
-	for _, key := range keys {
-		w.Write([]string{key, fmt.Sprint(m[key])})
-	}
-	w.Flush()
-}
-
-func listCSV(writer io.Writer, many []map[string]interface{}, keys []string) {
-	w := csv.NewWriter(writer)
-	w.Write(keys)
-	for _, m := range many {
-		f := []string{}
-		for _, key := range keys {
-			f = append(f, fmt.Sprint(m[key]))
-		}
-		w.Write(f)
-	}
-	w.Flush()
-}
-
 func MetadataCSV(writer io.Writer, m map[string]interface{}, keys []string) {
 	w := csv.NewWriter(writer)
 	w.Write([]string{"PROPERTY", "VALUE"})

--- a/output/json.go
+++ b/output/json.go
@@ -9,24 +9,6 @@ import (
 // INDENT is the indentation passed to json.MarshalIndent
 const INDENT string = "  "
 
-func defaultJSON(w io.Writer, i interface{}) {
-	m := map[string]interface{}{"result": i}
-	jsonOut(w, m)
-}
-
-func metadataJSON(w io.Writer, m map[string]interface{}, keys []string) {
-	mLimited := limitJSONFields(m, keys)
-	jsonOut(w, mLimited)
-}
-
-func listJSON(w io.Writer, maps []map[string]interface{}, keys []string) {
-	mLimited := make([]map[string]interface{}, len(maps))
-	for i, m := range maps {
-		mLimited[i] = limitJSONFields(m, keys)
-	}
-	jsonOut(w, mLimited)
-}
-
 func limitJSONFields(m map[string]interface{}, keys []string) map[string]interface{} {
 	mLimited := make(map[string]interface{})
 	for _, key := range keys {

--- a/output/table.go
+++ b/output/table.go
@@ -7,30 +7,6 @@ import (
 	"text/tabwriter"
 )
 
-func listTable(writer io.Writer, many []map[string]interface{}, keys []string) {
-	w := tabwriter.NewWriter(writer, 0, 8, 1, '\t', 0)
-	// Write the header
-	fmt.Fprintln(w, strings.Join(keys, "\t"))
-	for _, m := range many {
-		f := []string{}
-		for _, key := range keys {
-			f = append(f, fmt.Sprint(m[key]))
-		}
-		fmt.Fprintln(w, strings.Join(f, "\t"))
-	}
-	w.Flush()
-}
-
-func metadataTable(writer io.Writer, m map[string]interface{}, keys []string) {
-	w := tabwriter.NewWriter(writer, 0, 8, 0, '\t', 0)
-	fmt.Fprintln(w, "PROPERTY\tVALUE")
-	for _, key := range keys {
-		val := fmt.Sprint(m[key])
-		fmt.Fprintf(w, "%s\t%s\n", key, strings.Replace(val, "\n", "\n\t", -1))
-	}
-	w.Flush()
-}
-
 func ListTable(writer io.Writer, many []map[string]interface{}, keys []string) {
 	w := tabwriter.NewWriter(writer, 0, 8, 1, '\t', 0)
 	// Write the header


### PR DESCRIPTION
In this PR:
- An `all-pages` flag for `list` commands
- A `StreamPipeHandler` for handling streams of input (as opposed to new-line delimited IDs) piped to STDIN: `cat objectToUpload | rack files object upload --container myContainer --stdin content`