### PR TITLE
Adding some friendly output for rack configure

### DIFF
--- a/configure.go
+++ b/configure.go
@@ -87,6 +87,13 @@ func configure(c *cli.Context) {
 		//fmt.Printf("Error saving config file: %s\n", err)
 		return
 	}
+
+	if profile == "DEFAULT" {
+	    fmt.Printf("\nCreated new default profile for username %s", username)
+	} else {
+	    fmt.Printf("\nCreated profile %s with username %s", profile, username)
+	}
+
 }
 
 func configFile() (string, error) {


### PR DESCRIPTION
```
/data/src/rack [output-for-configure]* $ ./rack configure

This interactive session will walk you through creating
a profile in your configuration file. You may fill in all or none of the
values.

Rackspace Username: kpraxtest
Rackspace API key: asdf
Rackspace Region : iad
Profile Name (leave blank to create a default profile): kpraxtest

Created profile kpraxtest with username kpraxtest
```
