### PR TITLE
Adding a contributing guide; closes #13

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,114 @@
+# Contribution Guide
+
+We welcome and encourage community contributions to `rack`.
+
+Please familiarize yourself with the Contribution Guidelines and Project Roadmap before contributing.
+
+There are many ways to help `rack` besides contributing code:
+
+ - Fix bugs or file issues
+ - Improve the [documentation](https://github.com/jrperritt/rack/tree/master/docs)
+
+## Contributing Code
+
+Unless you are fixing a known bug, we **strongly** recommend discussing it with the core team via a GitHub issue or on [Freenode IRC](irc://chat.freenode.net/rackspace) before getting started to ensure your work is consistent with `rack`'s roadmap and architecture.
+
+All contributions are made via pull request. Note that **all patches from all contributors get reviewed**. After a pull request is made other contributors will offer feedback, and if the patch passes review a maintainer will accept it with a comment. When pull requests fail testing, authors are expected to update their pull requests to address the failures until the tests pass and the pull request merges successfully.
+
+At least one review from a maintainer is required for all patches (even patches from maintainers).
+
+Reviewers should leave a `LGTM` or `:+1:` comment once they are satisfied with the patch. If the patch was submitted by a maintainer with write access, the pull request should be merged by the submitter after review.
+
+## Code Style
+
+Please follow these guidelines when formatting source code:
+
+* Go code should match the output of `gofmt -s`
+* Shell scripts should adhere to the [Google Shell Style guide](https://google-styleguide.googlecode.com/svn/trunk/shell.xml)
+
+## Developer’s Certificate of Origin
+
+All contributions must include acceptance of the DCO:
+
+```text
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+To accept the DCO, simply add this line to each commit message with your name and email address (`git commit -s` will do this for you):
+
+```text
+Signed-off-by: Jane Example <jane@example.com>
+```
+
+For legal reasons, no anonymous or pseudonymous contributions are accepted ([contact us](mailto:sdk-support@rackspace.com) if this is an issue).
+
+## Pull request procedure
+
+To make a pull request, you will need a GitHub account; if you are unclear on this process, see GitHub's documentation on [forking](https://help.github.com/articles/fork-a-repo) and [pull requests](https://help.github.com/articles/using-pull-requests). Pull requests should be targeted at the `master` branch. Before creating a pull request, go through this checklist:
+
+1. Create a feature branch off of `master` so that changes do not get mixed up.
+1. [Rebase](http://git-scm.com/book/en/Git-Branching-Rebasing) your local changes against the `master` branch.
+1. Run the full project test suite with the `go test ./...` (or equivalent) command and confirm that it passes.
+1. Run `gofmt -s` (if the project is written in Go).
+1. Accept the Developer's Certificate of Origin on all commits (see above).
+1. Ensure that each commit has a subsystem prefix (ex: `files: `).
+
+Pull requests will be treated as "review requests," and maintainers will give feedback on the style and substance of the patch.
+
+Normally, all pull requests must include tests that test your change. Occasionally, a change will be very difficult to test for. In those cases, please include a note in your commit message explaining why.
+
+## Communication
+
+We use the #rackspace IRC channel on [Freenode](irc://chat.freenode.net/rackspace). You are welcome to drop in and ask questions, discuss bugs, etc. You can [connect using webchat](https://webchat.freenode.net/?channels=rackspace) if you do not have an IRC client.
+
+## Conduct
+
+Whether you are a regular contributor or a newcomer, we care about making this community a safe place for you and we've got your back.
+
+* We are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, disability, ethnicity, religion, or similar personal characteristic.
+* Please avoid using nicknames that might detract from a friendly, safe and welcoming environment for all.
+* Be kind and courteous. There is no need to be mean or rude.
+* We will exclude you from interaction if you insult, demean or harass anyone. In particular, we do not tolerate behavior that excludes people in socially marginalized groups.
+* Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or a member of the `rack` core team immediately.
+* Likewise any spamming, trolling, flaming, baiting or other attention-stealing behaviour is not welcome.
+
+We welcome discussion about creating a welcoming, safe, and productive environment for the community. If you have any questions, feedback, or concerns [please let us know](mailto:sdk-support@rackspace.com).
+
+## Attribution
+
+This contributing guide was directly based off of the [Flynn contributing guide](https://github.com/flynn/flynn/blob/master/CONTRIBUTING.md). Thanks to the Flynn team for providing a great example!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,57 +26,6 @@ Please follow these guidelines when formatting source code:
 * Go code should match the output of `gofmt -s`
 * Shell scripts should adhere to the [Google Shell Style guide](https://google-styleguide.googlecode.com/svn/trunk/shell.xml)
 
-## Developer’s Certificate of Origin
-
-All contributions must include acceptance of the DCO:
-
-```text
-Developer Certificate of Origin
-Version 1.1
-
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-660 York Street, Suite 102,
-San Francisco, CA 94110 USA
-
-Everyone is permitted to copy and distribute verbatim copies of this
-license document, but changing it is not allowed.
-
-
-Developer's Certificate of Origin 1.1
-
-By making a contribution to this project, I certify that:
-
-(a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
-
-(b) The contribution is based upon previous work that, to the best
-    of my knowledge, is covered under an appropriate open source
-    license and I have the right under that license to submit that
-    work with modifications, whether created in whole or in part
-    by me, under the same open source license (unless I am
-    permitted to submit under a different license), as indicated
-    in the file; or
-
-(c) The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
-
-(d) I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
-```
-
-To accept the DCO, simply add this line to each commit message with your name and email address (`git commit -s` will do this for you):
-
-```text
-Signed-off-by: Jane Example <jane@example.com>
-```
-
-For legal reasons, no anonymous or pseudonymous contributions are accepted ([contact us](mailto:sdk-support@rackspace.com) if this is an issue).
-
 ## Pull request procedure
 
 To make a pull request, you will need a GitHub account; if you are unclear on this process, see GitHub's documentation on [forking](https://help.github.com/articles/fork-a-repo) and [pull requests](https://help.github.com/articles/using-pull-requests). Pull requests should be targeted at the `master` branch. Before creating a pull request, go through this checklist:
@@ -85,7 +34,6 @@ To make a pull request, you will need a GitHub account; if you are unclear on th
 1. [Rebase](http://git-scm.com/book/en/Git-Branching-Rebasing) your local changes against the `master` branch.
 1. Run the full project test suite with the `go test ./...` (or equivalent) command and confirm that it passes.
 1. Run `gofmt ./...`.
-1. Accept the Developer's Certificate of Origin on all commits (see above).
 1. Ensure that each commit has a subsystem prefix (ex: `files: `).
 
 Pull requests will be treated as "review requests," and maintainers will give feedback on the style and substance of the patch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ Whether you are a regular contributor or a newcomer, we care about making this c
 * Please avoid using nicknames that might detract from a friendly, safe and welcoming environment for all.
 * Be kind and courteous. There is no need to be mean or rude.
 * We will exclude you from interaction if you insult, demean or harass anyone. In particular, we do not tolerate behavior that excludes people in socially marginalized groups.
-* Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or a member of the `rack` core team immediately.
+* Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact a member of the `rack` core team immediately.
 * Likewise any spamming, trolling, flaming, baiting or other attention-stealing behaviour is not welcome.
 
 We welcome discussion about creating a welcoming, safe, and productive environment for the community. If you have any questions, feedback, or concerns [please let us know](mailto:sdk-support@rackspace.com).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ There are many ways to help `rack` besides contributing code:
 
 ## Contributing Code
 
-Unless you are fixing a known bug, we **strongly** recommend discussing it with the core team via a GitHub issue or on [Freenode IRC](irc://chat.freenode.net/rackspace) before getting started to ensure your work is consistent with `rack`'s roadmap and architecture.
+Unless you are fixing a known bug, we **strongly** recommend discussing it with the core team via a GitHub issue before getting started to ensure your work is consistent with `rack`'s roadmap and architecture.
 
 All contributions are made via pull request. Note that **all patches from all contributors get reviewed**. After a pull request is made other contributors will offer feedback, and if the patch passes review a maintainer will accept it with a comment. When pull requests fail testing, authors are expected to update their pull requests to address the failures until the tests pass and the pull request merges successfully.
 
@@ -91,10 +91,6 @@ To make a pull request, you will need a GitHub account; if you are unclear on th
 Pull requests will be treated as "review requests," and maintainers will give feedback on the style and substance of the patch.
 
 Normally, all pull requests must include tests that test your change. Occasionally, a change will be very difficult to test for. In those cases, please include a note in your commit message explaining why.
-
-## Communication
-
-We use the #rackspace IRC channel on [Freenode](irc://chat.freenode.net/rackspace). You are welcome to drop in and ask questions, discuss bugs, etc. You can [connect using webchat](https://webchat.freenode.net/?channels=rackspace) if you do not have an IRC client.
 
 ## Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Please familiarize yourself with the Contribution Guidelines and Project Roadmap
 
 There are many ways to help `rack` besides contributing code:
 
- - Fix bugs or file issues
+ - Find bugs or file issues
  - Improve the [documentation](https://github.com/jrperritt/rack/tree/master/docs)
 
 ## Contributing Code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ To make a pull request, you will need a GitHub account; if you are unclear on th
 1. Create a feature branch off of `master` so that changes do not get mixed up.
 1. [Rebase](http://git-scm.com/book/en/Git-Branching-Rebasing) your local changes against the `master` branch.
 1. Run the full project test suite with the `go test ./...` (or equivalent) command and confirm that it passes.
-1. Run `gofmt -s` (if the project is written in Go).
+1. Run `gofmt ./...`.
 1. Accept the Developer's Certificate of Origin on all commits (see above).
 1. Ensure that each commit has a subsystem prefix (ex: `files: `).
 

--- a/script/prep-travis-release.sh
+++ b/script/prep-travis-release.sh
@@ -19,7 +19,7 @@ IFS=$'\n\t'
 set +u
 
 if [[ -z "$GIMME_OS" && -z "$GIMME_ARCH" ]]; then
-  echo "GIMME_OS and GIMME_ARCH must be defined"
+  >&2 echo "GIMME_OS and GIMME_ARCH must be defined"
   exit 2
 fi
 
@@ -56,7 +56,7 @@ case $os in
     os="FreeBSD"
     ;;
   *)
-    echo "Unknown OS ${os}. Assuming it's a valid OS for gimme/go and charging ahead."
+    >&2 echo "Unknown OS ${os}. Assuming it's a valid OS for gimme/go and charging ahead."
 esac
 
 case $arch in

--- a/script/prep-travis-release.sh
+++ b/script/prep-travis-release.sh
@@ -11,6 +11,9 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+declare -xr CDN="https://ba7db30ac3f206168dbb-7f12cbe7f0a328a153fa25953cbec5f2.ssl.cf5.rackcdn.com"
+declare -xr BUILDDIR="build"
+
 
 ################################################################################
 # Disable strict temporarily to accept global environment variables that come
@@ -75,12 +78,9 @@ fi
 # Set up the build and deploy layout
 ################################################################################
 
-BUILDDIR="build"
 BASEDIR="${os}/${arch}"
 # Mirror the github layout for branches, tags, commits
 TREEDIR="${os}/${arch}/tree"
-
-CDN="https://ba7db30ac3f206168dbb-7f12cbe7f0a328a153fa25953cbec5f2.ssl.cf5.rackcdn.com"
 
 mkdir -p $BUILDDIR
 mkdir -p $BUILDDIR/$BASEDIR


### PR DESCRIPTION
This is a first pass of a contributing guide, based on the work from the Flynn team at https://github.com/flynn/flynn/blob/master/CONTRIBUTING.md.

It makes some assumptions on code style, and certificate of origin, but it was go specific, so I thought it was a good start.

Discussion to follow.

- Fixes #13