### PR TITLE
Ran `go fmt` according to #160.

### DIFF
--- a/auth/cache.go
+++ b/auth/cache.go
@@ -8,8 +8,8 @@ import (
 	"path"
 	"sync"
 
-	"github.com/jrperritt/rack/util"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud"
+	"github.com/jrperritt/rack/util"
 )
 
 // Cache represents a place to store user authentication credentials.

--- a/auth/clients.go
+++ b/auth/clients.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 
 	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
-	"github.com/jrperritt/rack/util"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace"
+	"github.com/jrperritt/rack/util"
 )
 
 // reauthFunc is what the ServiceClient uses to re-authenticate.

--- a/auth/configfile.go
+++ b/auth/configfile.go
@@ -5,8 +5,8 @@ import (
 	"path"
 
 	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
-	"github.com/jrperritt/rack/util"
 	"github.com/jrperritt/rack/internal/gopkg.in/ini.v1"
+	"github.com/jrperritt/rack/util"
 )
 
 func configfile(c *cli.Context, have map[string]authCred, need map[string]string) error {

--- a/commands/blockstoragecommands/commands.go
+++ b/commands/blockstoragecommands/commands.go
@@ -1,9 +1,9 @@
 package blockstoragecommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/commands/blockstoragecommands/snapshotcommands"
 	"github.com/jrperritt/rack/commands/blockstoragecommands/volumecommands"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 )
 
 // Get returns all the commands allowed for a `block-storage` request.

--- a/commands/blockstoragecommands/snapshotcommands/create.go
+++ b/commands/blockstoragecommands/snapshotcommands/create.go
@@ -1,10 +1,10 @@
 package snapshotcommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osSnapshots "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/blockstorage/v1/snapshots"
+	"github.com/jrperritt/rack/util"
 )
 
 var create = cli.Command{

--- a/commands/blockstoragecommands/snapshotcommands/delete.go
+++ b/commands/blockstoragecommands/snapshotcommands/delete.go
@@ -3,10 +3,10 @@ package snapshotcommands
 import (
 	"fmt"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osSnapshots "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/blockstorage/v1/snapshots"
+	"github.com/jrperritt/rack/util"
 )
 
 var remove = cli.Command{

--- a/commands/blockstoragecommands/snapshotcommands/get.go
+++ b/commands/blockstoragecommands/snapshotcommands/get.go
@@ -1,10 +1,10 @@
 package snapshotcommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osSnapshots "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/blockstorage/v1/snapshots"
+	"github.com/jrperritt/rack/util"
 )
 
 var get = cli.Command{

--- a/commands/blockstoragecommands/snapshotcommands/list.go
+++ b/commands/blockstoragecommands/snapshotcommands/list.go
@@ -1,11 +1,11 @@
 package snapshotcommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osSnapshots "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/blockstorage/v1/snapshots"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/pagination"
+	"github.com/jrperritt/rack/util"
 )
 
 var list = cli.Command{

--- a/commands/blockstoragecommands/volumecommands/create.go
+++ b/commands/blockstoragecommands/volumecommands/create.go
@@ -1,10 +1,10 @@
 package volumecommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osVolumes "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/blockstorage/v1/volumes"
+	"github.com/jrperritt/rack/util"
 )
 
 var create = cli.Command{

--- a/commands/blockstoragecommands/volumecommands/delete.go
+++ b/commands/blockstoragecommands/volumecommands/delete.go
@@ -3,10 +3,10 @@ package volumecommands
 import (
 	"fmt"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osVolumes "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/blockstorage/v1/volumes"
+	"github.com/jrperritt/rack/util"
 )
 
 var remove = cli.Command{

--- a/commands/blockstoragecommands/volumecommands/get.go
+++ b/commands/blockstoragecommands/volumecommands/get.go
@@ -1,10 +1,10 @@
 package volumecommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osVolumes "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/blockstorage/v1/volumes"
+	"github.com/jrperritt/rack/util"
 )
 
 var get = cli.Command{

--- a/commands/blockstoragecommands/volumecommands/list.go
+++ b/commands/blockstoragecommands/volumecommands/list.go
@@ -1,11 +1,11 @@
 package volumecommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osVolumes "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/blockstorage/v1/volumes"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/pagination"
+	"github.com/jrperritt/rack/util"
 )
 
 var list = cli.Command{

--- a/commands/blockstoragecommands/volumecommands/update.go
+++ b/commands/blockstoragecommands/volumecommands/update.go
@@ -1,10 +1,10 @@
 package volumecommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osVolumes "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/blockstorage/v1/volumes"
+	"github.com/jrperritt/rack/util"
 )
 
 var update = cli.Command{

--- a/commands/filescommands/commands.go
+++ b/commands/filescommands/commands.go
@@ -1,9 +1,9 @@
 package filescommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/commands/filescommands/containercommands"
 	"github.com/jrperritt/rack/commands/filescommands/objectcommands"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 )
 
 // Get returns all the commands allowed for a `files` request.

--- a/commands/filescommands/containercommands/create.go
+++ b/commands/filescommands/containercommands/create.go
@@ -3,10 +3,10 @@ package containercommands
 import (
 	"fmt"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/objectstorage/v1/containers"
+	"github.com/jrperritt/rack/util"
 )
 
 var get = cli.Command{

--- a/commands/filescommands/containercommands/create_test.go
+++ b/commands/filescommands/containercommands/create_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/objectstorage/v1/containers"
 	th "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper/client"

--- a/commands/filescommands/containercommands/delete.go
+++ b/commands/filescommands/containercommands/delete.go
@@ -5,11 +5,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/objectstorage/v1/objects"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/objectstorage/v1/containers"
+	"github.com/jrperritt/rack/util"
 )
 
 var remove = cli.Command{

--- a/commands/filescommands/containercommands/delete_test.go
+++ b/commands/filescommands/containercommands/delete_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	th "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper/client"
 )

--- a/commands/filescommands/containercommands/get.go
+++ b/commands/filescommands/containercommands/get.go
@@ -1,11 +1,11 @@
 package containercommands
 
 import (
+	"github.com/jrperritt/rack/handler"
 	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/fatih/structs"
-	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/objectstorage/v1/containers"
+	"github.com/jrperritt/rack/util"
 )
 
 var create = cli.Command{

--- a/commands/filescommands/containercommands/list.go
+++ b/commands/filescommands/containercommands/list.go
@@ -1,13 +1,13 @@
 package containercommands
 
 import (
+	"github.com/jrperritt/rack/handler"
 	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/fatih/structs"
-	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
 	osContainers "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/objectstorage/v1/containers"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/pagination"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/objectstorage/v1/containers"
+	"github.com/jrperritt/rack/util"
 )
 
 var list = cli.Command{

--- a/commands/filescommands/objectcommands/delete.go
+++ b/commands/filescommands/objectcommands/delete.go
@@ -3,10 +3,10 @@ package objectcommands
 import (
 	"fmt"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/objectstorage/v1/objects"
+	"github.com/jrperritt/rack/util"
 )
 
 var remove = cli.Command{

--- a/commands/filescommands/objectcommands/get.go
+++ b/commands/filescommands/objectcommands/get.go
@@ -1,11 +1,11 @@
 package objectcommands
 
 import (
+	"github.com/jrperritt/rack/handler"
 	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/fatih/structs"
-	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/objectstorage/v1/objects"
+	"github.com/jrperritt/rack/util"
 )
 
 var get = cli.Command{

--- a/commands/filescommands/objectcommands/list.go
+++ b/commands/filescommands/objectcommands/list.go
@@ -1,13 +1,13 @@
 package objectcommands
 
 import (
+	"github.com/jrperritt/rack/handler"
 	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/fatih/structs"
-	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
 	osObjects "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/objectstorage/v1/objects"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/pagination"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/objectstorage/v1/objects"
+	"github.com/jrperritt/rack/util"
 )
 
 var list = cli.Command{

--- a/commands/networkscommands/commands.go
+++ b/commands/networkscommands/commands.go
@@ -1,12 +1,12 @@
 package networkscommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/commands/networkscommands/networkcommands"
 	"github.com/jrperritt/rack/commands/networkscommands/portcommands"
 	"github.com/jrperritt/rack/commands/networkscommands/securitygroupcommands"
 	"github.com/jrperritt/rack/commands/networkscommands/securitygrouprulecommands"
 	"github.com/jrperritt/rack/commands/networkscommands/subnetcommands"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 )
 
 // Get returns all the commands allowed for a `networks` request.

--- a/commands/networkscommands/networkcommands/create.go
+++ b/commands/networkscommands/networkcommands/create.go
@@ -1,11 +1,11 @@
 package networkcommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osNetworks "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/networks"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/networks"
+	"github.com/jrperritt/rack/util"
 )
 
 var create = cli.Command{

--- a/commands/networkscommands/networkcommands/delete.go
+++ b/commands/networkscommands/networkcommands/delete.go
@@ -3,11 +3,11 @@ package networkcommands
 import (
 	"fmt"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osNetworks "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/networks"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/networks"
+	"github.com/jrperritt/rack/util"
 )
 
 var remove = cli.Command{

--- a/commands/networkscommands/networkcommands/get.go
+++ b/commands/networkscommands/networkcommands/get.go
@@ -1,11 +1,11 @@
 package networkcommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osNetworks "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/networks"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/networks"
+	"github.com/jrperritt/rack/util"
 )
 
 var get = cli.Command{

--- a/commands/networkscommands/networkcommands/list.go
+++ b/commands/networkscommands/networkcommands/list.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osNetworks "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/networks"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/pagination"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/networks"
+	"github.com/jrperritt/rack/util"
 )
 
 var list = cli.Command{

--- a/commands/networkscommands/networkcommands/update.go
+++ b/commands/networkscommands/networkcommands/update.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osNetworks "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/networks"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/networks"
+	"github.com/jrperritt/rack/util"
 )
 
 var update = cli.Command{

--- a/commands/networkscommands/portcommands/create.go
+++ b/commands/networkscommands/portcommands/create.go
@@ -1,11 +1,11 @@
 package portcommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osPorts "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/ports"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/ports"
+	"github.com/jrperritt/rack/util"
 )
 
 var create = cli.Command{

--- a/commands/networkscommands/portcommands/delete.go
+++ b/commands/networkscommands/portcommands/delete.go
@@ -3,11 +3,11 @@ package portcommands
 import (
 	"fmt"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osPorts "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/ports"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/ports"
+	"github.com/jrperritt/rack/util"
 )
 
 var remove = cli.Command{

--- a/commands/networkscommands/portcommands/get.go
+++ b/commands/networkscommands/portcommands/get.go
@@ -1,11 +1,11 @@
 package portcommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osPorts "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/ports"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/ports"
+	"github.com/jrperritt/rack/util"
 )
 
 var get = cli.Command{

--- a/commands/networkscommands/portcommands/list.go
+++ b/commands/networkscommands/portcommands/list.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osPorts "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/ports"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/pagination"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/ports"
+	"github.com/jrperritt/rack/util"
 )
 
 var list = cli.Command{

--- a/commands/networkscommands/portcommands/update.go
+++ b/commands/networkscommands/portcommands/update.go
@@ -5,11 +5,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osPorts "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/ports"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/ports"
+	"github.com/jrperritt/rack/util"
 )
 
 var update = cli.Command{

--- a/commands/networkscommands/securitygroupcommands/create.go
+++ b/commands/networkscommands/securitygroupcommands/create.go
@@ -1,11 +1,11 @@
 package securitygroupcommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osSecurityGroups "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/extensions/security/groups"
 	securityGroups "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/security/groups"
+	"github.com/jrperritt/rack/util"
 )
 
 var create = cli.Command{

--- a/commands/networkscommands/securitygroupcommands/delete.go
+++ b/commands/networkscommands/securitygroupcommands/delete.go
@@ -3,11 +3,11 @@ package securitygroupcommands
 import (
 	"fmt"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osSecurityGroups "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/extensions/security/groups"
 	securityGroups "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/security/groups"
+	"github.com/jrperritt/rack/util"
 )
 
 var remove = cli.Command{

--- a/commands/networkscommands/securitygroupcommands/get.go
+++ b/commands/networkscommands/securitygroupcommands/get.go
@@ -1,11 +1,11 @@
 package securitygroupcommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osSecurityGroups "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/extensions/security/groups"
 	securityGroups "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/security/groups"
+	"github.com/jrperritt/rack/util"
 )
 
 var get = cli.Command{

--- a/commands/networkscommands/securitygroupcommands/list.go
+++ b/commands/networkscommands/securitygroupcommands/list.go
@@ -1,12 +1,12 @@
 package securitygroupcommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osSecurityGroups "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/pagination"
 	securityGroups "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/security/groups"
+	"github.com/jrperritt/rack/util"
 )
 
 var list = cli.Command{

--- a/commands/networkscommands/securitygrouprulecommands/create.go
+++ b/commands/networkscommands/securitygrouprulecommands/create.go
@@ -3,11 +3,11 @@ package securitygrouprulecommands
 import (
 	"fmt"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osSecurityGroupRules "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/extensions/security/rules"
 	securityGroupRules "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/security/rules"
+	"github.com/jrperritt/rack/util"
 )
 
 var create = cli.Command{

--- a/commands/networkscommands/securitygrouprulecommands/delete.go
+++ b/commands/networkscommands/securitygrouprulecommands/delete.go
@@ -3,10 +3,10 @@ package securitygrouprulecommands
 import (
 	"fmt"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	securityGroupRules "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/security/rules"
+	"github.com/jrperritt/rack/util"
 )
 
 var remove = cli.Command{

--- a/commands/networkscommands/securitygrouprulecommands/get.go
+++ b/commands/networkscommands/securitygrouprulecommands/get.go
@@ -1,10 +1,10 @@
 package securitygrouprulecommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	securityGroupRules "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/security/rules"
+	"github.com/jrperritt/rack/util"
 )
 
 var get = cli.Command{

--- a/commands/networkscommands/securitygrouprulecommands/list.go
+++ b/commands/networkscommands/securitygrouprulecommands/list.go
@@ -3,12 +3,12 @@ package securitygrouprulecommands
 import (
 	"fmt"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osSecurityGroupRules "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/extensions/security/rules"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/pagination"
 	securityGroupRules "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/security/rules"
+	"github.com/jrperritt/rack/util"
 )
 
 var list = cli.Command{

--- a/commands/networkscommands/subnetcommands/create.go
+++ b/commands/networkscommands/subnetcommands/create.go
@@ -3,11 +3,11 @@ package subnetcommands
 import (
 	"strings"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osSubnets "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/subnets"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/subnets"
+	"github.com/jrperritt/rack/util"
 )
 
 var create = cli.Command{

--- a/commands/networkscommands/subnetcommands/delete.go
+++ b/commands/networkscommands/subnetcommands/delete.go
@@ -3,11 +3,11 @@ package subnetcommands
 import (
 	"fmt"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osSubnets "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/subnets"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/subnets"
+	"github.com/jrperritt/rack/util"
 )
 
 var remove = cli.Command{

--- a/commands/networkscommands/subnetcommands/get.go
+++ b/commands/networkscommands/subnetcommands/get.go
@@ -1,11 +1,11 @@
 package subnetcommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osSubnets "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/subnets"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/subnets"
+	"github.com/jrperritt/rack/util"
 )
 
 var get = cli.Command{

--- a/commands/networkscommands/subnetcommands/list.go
+++ b/commands/networkscommands/subnetcommands/list.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osSubnets "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/subnets"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/pagination"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/subnets"
+	"github.com/jrperritt/rack/util"
 )
 
 var list = cli.Command{

--- a/commands/networkscommands/subnetcommands/update.go
+++ b/commands/networkscommands/subnetcommands/update.go
@@ -3,11 +3,11 @@ package subnetcommands
 import (
 	"strings"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osSubnets "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/networking/v2/subnets"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/networking/v2/subnets"
+	"github.com/jrperritt/rack/util"
 )
 
 var update = cli.Command{

--- a/commands/serverscommands/commands.go
+++ b/commands/serverscommands/commands.go
@@ -1,11 +1,11 @@
 package serverscommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/commands/serverscommands/flavorcommands"
 	"github.com/jrperritt/rack/commands/serverscommands/imagecommands"
 	"github.com/jrperritt/rack/commands/serverscommands/instancecommands"
 	"github.com/jrperritt/rack/commands/serverscommands/keypaircommands"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 )
 
 // Get returns all the commands allowed for a `servers` request.

--- a/commands/serverscommands/flavorcommands/get.go
+++ b/commands/serverscommands/flavorcommands/get.go
@@ -1,12 +1,12 @@
 package flavorcommands
 
 import (
+	"github.com/jrperritt/rack/handler"
 	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/fatih/structs"
-	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/flavors"
 	osFlavors "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/flavors"
+	"github.com/jrperritt/rack/util"
 )
 
 var get = cli.Command{

--- a/commands/serverscommands/flavorcommands/list.go
+++ b/commands/serverscommands/flavorcommands/list.go
@@ -1,12 +1,12 @@
 package flavorcommands
 
 import (
+	"github.com/jrperritt/rack/handler"
 	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/fatih/structs"
-	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/pagination"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/flavors"
+	"github.com/jrperritt/rack/util"
 )
 
 var list = cli.Command{

--- a/commands/serverscommands/imagecommands/get.go
+++ b/commands/serverscommands/imagecommands/get.go
@@ -1,12 +1,12 @@
 package imagecommands
 
 import (
+	"github.com/jrperritt/rack/handler"
 	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/fatih/structs"
-	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
 	osImages "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/images"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/images"
+	"github.com/jrperritt/rack/util"
 )
 
 var get = cli.Command{

--- a/commands/serverscommands/imagecommands/list.go
+++ b/commands/serverscommands/imagecommands/list.go
@@ -1,13 +1,13 @@
 package imagecommands
 
 import (
+	"github.com/jrperritt/rack/handler"
 	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/fatih/structs"
-	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
 	osImages "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/images"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/pagination"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/images"
+	"github.com/jrperritt/rack/util"
 )
 
 var list = cli.Command{

--- a/commands/serverscommands/instancecommands/create.go
+++ b/commands/serverscommands/instancecommands/create.go
@@ -4,11 +4,11 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osServers "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
+	"github.com/jrperritt/rack/util"
 )
 
 var create = cli.Command{

--- a/commands/serverscommands/instancecommands/create_test.go
+++ b/commands/serverscommands/instancecommands/create_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osServers "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
 	th "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper"

--- a/commands/serverscommands/instancecommands/delete.go
+++ b/commands/serverscommands/instancecommands/delete.go
@@ -3,11 +3,11 @@ package instancecommands
 import (
 	"fmt"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osServers "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
+	"github.com/jrperritt/rack/util"
 )
 
 // delete is a reserved word in Go.

--- a/commands/serverscommands/instancecommands/delete_test.go
+++ b/commands/serverscommands/instancecommands/delete_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	th "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper/client"
 )

--- a/commands/serverscommands/instancecommands/get.go
+++ b/commands/serverscommands/instancecommands/get.go
@@ -1,11 +1,11 @@
 package instancecommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osServers "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
+	"github.com/jrperritt/rack/util"
 )
 
 var get = cli.Command{

--- a/commands/serverscommands/instancecommands/get_test.go
+++ b/commands/serverscommands/instancecommands/get_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	th "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper/client"
 )

--- a/commands/serverscommands/instancecommands/list.go
+++ b/commands/serverscommands/instancecommands/list.go
@@ -1,12 +1,12 @@
 package instancecommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osServers "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/pagination"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
+	"github.com/jrperritt/rack/util"
 )
 
 var list = cli.Command{

--- a/commands/serverscommands/instancecommands/list_test.go
+++ b/commands/serverscommands/instancecommands/list_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osServers "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	th "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper/client"

--- a/commands/serverscommands/instancecommands/reboot.go
+++ b/commands/serverscommands/instancecommands/reboot.go
@@ -3,12 +3,12 @@ package instancecommands
 import (
 	"fmt"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/output"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osServers "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
+	"github.com/jrperritt/rack/output"
+	"github.com/jrperritt/rack/util"
 )
 
 var reboot = cli.Command{

--- a/commands/serverscommands/instancecommands/reboot_test.go
+++ b/commands/serverscommands/instancecommands/reboot_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osServers "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	th "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper/client"

--- a/commands/serverscommands/instancecommands/rebuild.go
+++ b/commands/serverscommands/instancecommands/rebuild.go
@@ -1,11 +1,11 @@
 package instancecommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osServers "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
+	"github.com/jrperritt/rack/util"
 )
 
 var rebuild = cli.Command{

--- a/commands/serverscommands/instancecommands/rebuild_test.go
+++ b/commands/serverscommands/instancecommands/rebuild_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/extensions/diskconfig"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
 	th "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper"

--- a/commands/serverscommands/instancecommands/resize.go
+++ b/commands/serverscommands/instancecommands/resize.go
@@ -3,11 +3,11 @@ package instancecommands
 import (
 	"fmt"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osServers "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
+	"github.com/jrperritt/rack/util"
 )
 
 var resize = cli.Command{

--- a/commands/serverscommands/instancecommands/resize_test.go
+++ b/commands/serverscommands/instancecommands/resize_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osServers "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	th "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper/client"

--- a/commands/serverscommands/instancecommands/update.go
+++ b/commands/serverscommands/instancecommands/update.go
@@ -1,11 +1,11 @@
 package instancecommands
 
 import (
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osServers "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/servers"
+	"github.com/jrperritt/rack/util"
 )
 
 var update = cli.Command{

--- a/commands/serverscommands/instancecommands/update_test.go
+++ b/commands/serverscommands/instancecommands/update_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osServers "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers"
 	th "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper/client"

--- a/commands/serverscommands/keypaircommands/delete.go
+++ b/commands/serverscommands/keypaircommands/delete.go
@@ -3,10 +3,10 @@ package keypaircommands
 import (
 	"fmt"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/keypairs"
+	"github.com/jrperritt/rack/util"
 )
 
 var remove = cli.Command{

--- a/commands/serverscommands/keypaircommands/delete_test.go
+++ b/commands/serverscommands/keypaircommands/delete_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	th "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper/client"
 )

--- a/commands/serverscommands/keypaircommands/generate.go
+++ b/commands/serverscommands/keypaircommands/generate.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jrperritt/rack/handler"
 	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/fatih/structs"
-	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
 	osKeypairs "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/keypairs"
+	"github.com/jrperritt/rack/util"
 )
 
 var generate = cli.Command{

--- a/commands/serverscommands/keypaircommands/generate_test.go
+++ b/commands/serverscommands/keypaircommands/generate_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osKeypairs "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/extensions/keypairs"
 	th "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper/client"

--- a/commands/serverscommands/keypaircommands/get.go
+++ b/commands/serverscommands/keypaircommands/get.go
@@ -1,11 +1,11 @@
 package keypaircommands
 
 import (
+	"github.com/jrperritt/rack/handler"
 	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/fatih/structs"
-	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/keypairs"
+	"github.com/jrperritt/rack/util"
 )
 
 var get = cli.Command{

--- a/commands/serverscommands/keypaircommands/get_test.go
+++ b/commands/serverscommands/keypaircommands/get_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	th "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper/client"
 )

--- a/commands/serverscommands/keypaircommands/list.go
+++ b/commands/serverscommands/keypaircommands/list.go
@@ -1,13 +1,13 @@
 package keypaircommands
 
 import (
+	"github.com/jrperritt/rack/handler"
 	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/fatih/structs"
-	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
 	osKeypairs "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/pagination"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/keypairs"
+	"github.com/jrperritt/rack/util"
 )
 
 var list = cli.Command{

--- a/commands/serverscommands/keypaircommands/upload.go
+++ b/commands/serverscommands/keypaircommands/upload.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/jrperritt/rack/handler"
 	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/internal/github.com/fatih/structs"
-	"github.com/jrperritt/rack/handler"
-	"github.com/jrperritt/rack/util"
 	osKeypairs "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/rackspace/compute/v2/keypairs"
+	"github.com/jrperritt/rack/util"
 )
 
 var upload = cli.Command{

--- a/commands/serverscommands/keypaircommands/upload_test.go
+++ b/commands/serverscommands/keypaircommands/upload_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	"github.com/jrperritt/rack/handler"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
 	osKeypairs "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/openstack/compute/v2/extensions/keypairs"
 	th "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper"
 	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud/testhelper/client"

--- a/configure.go
+++ b/configure.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
-	"github.com/jrperritt/rack/util"
 	"github.com/jrperritt/rack/internal/gopkg.in/ini.v1"
+	"github.com/jrperritt/rack/util"
 )
 
 func configure(c *cli.Context) {


### PR DESCRIPTION
Ran `gofmt` across the project (`go fmt ./...`), to conform with style guide in #160.

Note that one of the dependencies, gophercloud has a single non-`go fmt`. I didn't include this one:

```diff
diff --git a/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers/results.go b/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers/results.go
index 554792c..897b9e6 100644
--- a/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers/results.go
+++ b/internal/github.com/rackspace/gophercloud/openstack/compute/v2/servers/results.go
@@ -1,10 +1,10 @@
 package servers

 import (
-       "reflect"
        "fmt"
-       "path"
        "net/url"
+       "path"
+       "reflect"

        "github.com/jrperritt/rack/internal/github.com/mitchellh/mapstructure"
        "github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud"
```