### PR TITLE
remove wait groups; allow override of output functions

### DIFF
--- a/auth/clients.go
+++ b/auth/clients.go
@@ -51,7 +51,7 @@ func NewClient(c *cli.Context, serviceType string, logger *logrus.Logger) (*goph
 			pc.TokenID = creds.TokenID
 			pc.ReauthFunc = reauthFunc(pc, *ao)
 			pc.UserAgent.Prepend(util.UserAgent)
-			pc.HTTPClient = NewHTTPClient()
+			pc.HTTPClient = newHTTPClient()
 			return &gophercloud.ServiceClient{
 				ProviderClient: pc,
 				Endpoint:       creds.ServiceEndpoint,
@@ -70,7 +70,7 @@ func authFromScratch(ao gophercloud.AuthOptions, region, serviceType string, log
 	if err != nil {
 		return nil, err
 	}
-	pc.HTTPClient = NewHTTPClient()
+	pc.HTTPClient = newHTTPClient()
 	var sc *gophercloud.ServiceClient
 	switch serviceType {
 	case "compute":
@@ -198,9 +198,9 @@ type LogRoundTripper struct {
 	rt     http.RoundTripper
 }
 
-// NewHTTPClient return a custom HTTP client that allows for logging relevant
+// newHTTPClient return a custom HTTP client that allows for logging relevant
 // information before and after the HTTP request.
-func NewHTTPClient() http.Client {
+func newHTTPClient() http.Client {
 	return http.Client{
 		Transport: &LogRoundTripper{
 			rt: http.DefaultTransport,
@@ -225,6 +225,8 @@ func (lrt *LogRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 	if err != nil {
 		return response, err
 	}
+
+	lrt.Logger.Debugf("Response Status: %s\n", response.Status)
 
 	info, err := json.MarshalIndent(response.Header, "", "  ")
 	if err != nil {

--- a/commands/filescommands/containercommands/list.go
+++ b/commands/filescommands/containercommands/list.go
@@ -130,7 +130,6 @@ func (command *commandList) Execute(resource *handler.Resource) {
 				return false, nil
 			}
 			limit -= len(info)
-			command.Ctx.WaitGroup.Add(1)
 			command.Ctx.Results <- resource
 			return true, nil
 		})

--- a/commands/filescommands/objectcommands/download.go
+++ b/commands/filescommands/objectcommands/download.go
@@ -1,6 +1,7 @@
 package objectcommands
 
 import (
+	"io"
 	"io/ioutil"
 
 	"github.com/jrperritt/rack/handler"
@@ -85,14 +86,14 @@ func (command *commandDownload) Execute(resource *handler.Resource) {
 		resource.Err = rawResponse.Err
 		return
 	}
-	if command.Ctx.OutputFormat == "json" {
-		bytes, err := ioutil.ReadAll(rawResponse.Body)
-		if err != nil {
-			resource.Err = err
-			return
-		}
-		resource.Result = string(bytes)
-	} else {
-		resource.Result = rawResponse.Body
+	resource.Result = rawResponse.Body
+}
+
+func (command *commandDownload) JSON(resource *handler.Resource) {
+	bytes, err := ioutil.ReadAll(resource.Result.(io.Reader))
+	if err != nil {
+		resource.Err = err
+		return
 	}
+	resource.Result = string(bytes)
 }

--- a/commands/filescommands/objectcommands/get.go
+++ b/commands/filescommands/objectcommands/get.go
@@ -32,7 +32,7 @@ func flagsGet() []cli.Flag {
 	}
 }
 
-var keysGet = []string{"Name", "ContentLength", "ContentType", "StaticLargeObject"}
+var keysGet = []string{"Name", "ContentLength", "ContentType", "StaticLargeObject", "Metadata"}
 
 type paramsGet struct {
 	container string
@@ -99,9 +99,12 @@ func (command *commandGet) Execute(resource *handler.Resource) {
 		return
 	}
 	resource.Result = structs.Map(objectInfo)
+	//res := resource.Result.(map[string]interface{})
+	if metadata, ok := resource.Result.(map[string]interface{})["Metadata"]; ok {
+		for k, v := range metadata.(map[string]string) {
+			resource.Result.(map[string]interface{})[k] = v
+		}
+	}
+	delete(resource.Result.(map[string]interface{}), "Metadata")
 	resource.Result.(map[string]interface{})["Name"] = objectName
-}
-
-func (command *commandGet) StdinField() string {
-	return "name"
 }

--- a/commands/filescommands/objectcommands/get.go
+++ b/commands/filescommands/objectcommands/get.go
@@ -111,16 +111,7 @@ func (command *commandGet) Execute(resource *handler.Resource) {
 }
 
 func (command *commandGet) CSV(resource *handler.Resource) {
-	keys := resource.Keys
-	res := resource.Result.(map[string]interface{})
-	if metadata, ok := res["Metadata"]; ok && util.Contains(keys, "Metadata") {
-		for k, v := range metadata.(map[string]string) {
-			res[k] = v
-			keys = append(keys, k)
-		}
-	}
-	delete(res, "Metadata")
-	resource.Keys = util.RemoveFromList(keys, "Metadata")
+	command.Context().HandleMetadata(resource)
 }
 
 func (command *commandGet) Table(resource *handler.Resource) {

--- a/commands/filescommands/objectcommands/get.go
+++ b/commands/filescommands/objectcommands/get.go
@@ -32,7 +32,8 @@ func flagsGet() []cli.Flag {
 	}
 }
 
-var keysGet = []string{"Name", "ContentLength", "ContentType", "StaticLargeObject", "Metadata"}
+var keysGet = []string{"Name", "ContentDisposition", "ContentEncoding", "ContentLength",
+	"ContentType", "StaticLargeObject", "ObjectManifest", "TransID", "Metadata"}
 
 type paramsGet struct {
 	container string
@@ -93,18 +94,35 @@ func (command *commandGet) HandleSingle(resource *handler.Resource) error {
 func (command *commandGet) Execute(resource *handler.Resource) {
 	containerName := resource.Params.(*paramsGet).container
 	objectName := resource.Params.(*paramsGet).object
-	objectInfo, err := objects.Get(command.Ctx.ServiceClient, containerName, objectName, nil).Extract()
+	objectRaw := objects.Get(command.Ctx.ServiceClient, containerName, objectName, nil)
+	objectInfo, err := objectRaw.Extract()
+	if err != nil {
+		resource.Err = err
+		return
+	}
+	objectMetadata, err := objectRaw.ExtractMetadata()
 	if err != nil {
 		resource.Err = err
 		return
 	}
 	resource.Result = structs.Map(objectInfo)
-	//res := resource.Result.(map[string]interface{})
-	if metadata, ok := resource.Result.(map[string]interface{})["Metadata"]; ok {
+	resource.Result.(map[string]interface{})["Name"] = objectName
+	resource.Result.(map[string]interface{})["Metadata"] = objectMetadata
+}
+
+func (command *commandGet) CSV(resource *handler.Resource) {
+	keys := resource.Keys
+	res := resource.Result.(map[string]interface{})
+	if metadata, ok := res["Metadata"]; ok && util.Contains(keys, "Metadata") {
 		for k, v := range metadata.(map[string]string) {
-			resource.Result.(map[string]interface{})[k] = v
+			res[k] = v
+			keys = append(keys, k)
 		}
 	}
-	delete(resource.Result.(map[string]interface{}), "Metadata")
-	resource.Result.(map[string]interface{})["Name"] = objectName
+	delete(res, "Metadata")
+	resource.Keys = util.RemoveFromList(keys, "Metadata")
+}
+
+func (command *commandGet) Table(resource *handler.Resource) {
+	command.CSV(resource)
 }

--- a/commands/filescommands/objectcommands/list.go
+++ b/commands/filescommands/objectcommands/list.go
@@ -154,7 +154,6 @@ func (command *commandList) Execute(resource *handler.Resource) {
 				return false, nil
 			}
 			limit -= len(info)
-			command.Ctx.WaitGroup.Add(1)
 			command.Ctx.Results <- resource
 			return true, nil
 		})

--- a/commands/filescommands/objectcommands/upload.go
+++ b/commands/filescommands/objectcommands/upload.go
@@ -58,6 +58,10 @@ func flagsUpload() []cli.Flag {
 			Name:  "content-encoding",
 			Usage: "[optional] The Content-Encoding header. By default, the uploaded content will be gzipped.",
 		},
+		cli.StringFlag{
+			Name:  "metadata",
+			Usage: "[optional] A comma-separated string a key=value pairs.",
+		},
 	}
 }
 
@@ -108,6 +112,14 @@ func (command *commandUpload) HandleFlags(resource *handler.Resource) error {
 
 	if c.IsSet("content-encoding") && c.String("content-encoding") != "gzip" {
 		opts.ContentEncoding = c.String("content-encoding")
+	}
+
+	if c.IsSet("metadata") {
+		metadata, err := command.Ctx.CheckKVFlag("metadata")
+		if err != nil {
+			return err
+		}
+		opts.Metadata = metadata
 	}
 
 	resource.Params = &paramsUpload{

--- a/commands/networkscommands/networkcommands/list.go
+++ b/commands/networkscommands/networkcommands/list.go
@@ -158,7 +158,6 @@ func (command *commandList) Execute(resource *handler.Resource) {
 				return false, nil
 			}
 			limit -= len(info)
-			command.Ctx.WaitGroup.Add(1)
 			command.Ctx.Results <- resource
 			return true, nil
 		})

--- a/commands/networkscommands/portcommands/list.go
+++ b/commands/networkscommands/portcommands/list.go
@@ -164,7 +164,6 @@ func (command *commandList) Execute(resource *handler.Resource) {
 				return false, nil
 			}
 			limit -= len(info)
-			command.Ctx.WaitGroup.Add(1)
 			command.Ctx.Results <- resource
 			return true, nil
 		})

--- a/commands/networkscommands/securitygroupcommands/list.go
+++ b/commands/networkscommands/securitygroupcommands/list.go
@@ -129,7 +129,6 @@ func (command *commandList) Execute(resource *handler.Resource) {
 				return false, nil
 			}
 			limit -= len(info)
-			command.Ctx.WaitGroup.Add(1)
 			command.Ctx.Results <- resource
 			return true, nil
 		})

--- a/commands/networkscommands/securitygrouprulecommands/list.go
+++ b/commands/networkscommands/securitygrouprulecommands/list.go
@@ -171,7 +171,6 @@ func (command *commandList) Execute(resource *handler.Resource) {
 				return false, nil
 			}
 			limit -= len(info)
-			command.Ctx.WaitGroup.Add(1)
 			command.Ctx.Results <- resource
 			return true, nil
 		})

--- a/commands/networkscommands/subnetcommands/list.go
+++ b/commands/networkscommands/subnetcommands/list.go
@@ -161,7 +161,6 @@ func (command *commandList) Execute(resource *handler.Resource) {
 				return false, nil
 			}
 			limit -= len(info)
-			command.Ctx.WaitGroup.Add(1)
 			command.Ctx.Results <- resource
 			return true, nil
 		})

--- a/commands/serverscommands/flavorcommands/list.go
+++ b/commands/serverscommands/flavorcommands/list.go
@@ -126,7 +126,6 @@ func (command *commandList) Execute(resource *handler.Resource) {
 				return false, nil
 			}
 			limit -= len(info)
-			command.Ctx.WaitGroup.Add(1)
 			command.Ctx.Results <- resource
 			return true, nil
 		})

--- a/commands/serverscommands/imagecommands/list.go
+++ b/commands/serverscommands/imagecommands/list.go
@@ -127,7 +127,6 @@ func (command *commandList) Execute(resource *handler.Resource) {
 				return false, nil
 			}
 			limit -= len(info)
-			command.Ctx.WaitGroup.Add(1)
 			command.Ctx.Results <- resource
 			return true, nil
 		})

--- a/commands/serverscommands/instancecommands/list.go
+++ b/commands/serverscommands/instancecommands/list.go
@@ -141,7 +141,6 @@ func (command *commandList) Execute(resource *handler.Resource) {
 				return false, nil
 			}
 			limit -= len(info)
-			command.Ctx.WaitGroup.Add(1)
 			command.Ctx.Results <- resource
 			return true, nil
 		})

--- a/commands/serverscommands/keypaircommands/generate.go
+++ b/commands/serverscommands/keypaircommands/generate.go
@@ -93,24 +93,20 @@ func (command *commandGenerate) Execute(resource *handler.Resource) {
 		resource.Err = err
 		return
 	}
-
-	if command.Ctx.OutputFormat == "json" || command.Ctx.OutputFormat == "csv" {
-		resource.Result = structs.Map(keypair)
-	} else {
-		resource.Result = printGenerate(keypair)
-	}
+	resource.Result = structs.Map(keypair)
 }
 
 func (command *commandGenerate) StdinField() string {
 	return "name"
 }
 
-func printGenerate(kp *osKeypairs.KeyPair) string {
+func (command *commandGenerate) Table(resource *handler.Resource) {
 	output := []string{"PROPERTY\tVALUE",
 		"Name\t\t%s",
 		"Fingerprint\t%s",
 		"PublicKey\t%s",
 		"PrivateKey:\n%s",
 	}
-	return fmt.Sprintf(strings.Join(output, "\n"), kp.Name, kp.Fingerprint, kp.PublicKey, kp.PrivateKey)
+	kp := resource.Result.(map[string]interface{})
+	resource.Result = fmt.Sprintf(strings.Join(output, "\n"), kp["Name"], kp["Fingerprint"], kp["PublicKey"], kp["PrivateKey"])
 }

--- a/commands/serverscommands/keypaircommands/get.go
+++ b/commands/serverscommands/keypaircommands/get.go
@@ -87,15 +87,17 @@ func (command *commandGet) Execute(resource *handler.Resource) {
 		resource.Err = err
 		return
 	}
-	result := structs.Map(keypair)
-	if command.Ctx.OutputFormat == "json" {
-		resource.Result = result
-	} else {
-		// Assume they want the key directly
-		resource.Result = result["PublicKey"]
-	}
+	resource.Result = structs.Map(keypair)
 }
 
 func (command *commandGet) StdinField() string {
 	return "name"
+}
+
+func (command *commandGet) CSV(resource *handler.Resource) {
+	resource.Result = resource.Result.(map[string]interface{})["PublicKey"]
+}
+
+func (command *commandGet) Table(resource *handler.Resource) {
+	command.CSV(resource)
 }

--- a/handler/context.go
+++ b/handler/context.go
@@ -1,12 +1,8 @@
 package handler
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"os"
 	"strings"
-	"sync"
 
 	"github.com/jrperritt/rack/auth"
 	"github.com/jrperritt/rack/internal/github.com/Sirupsen/logrus"
@@ -18,6 +14,7 @@ import (
 
 // Command is the type that commands have.
 type Command struct {
+	// See `Context`
 	Ctx *Context
 }
 
@@ -31,128 +28,14 @@ type Context struct {
 	ServiceClient *gophercloud.ServiceClient
 	// ServiceClientType is the type of Rackspace service client used (e.g. compute).
 	ServiceClientType string
-	// WaitGroup is used for synchronizing output.
-	WaitGroup *sync.WaitGroup
 	// Results is a channel into which commands send results. It allows for streaming
 	// output.
 	Results chan *Resource
-	// OutputFormat is the format in which the user wants the output. This is obtained
+	// outputFormat is the format in which the user wants the output. This is obtained
 	// from the `output` flag and will default to "table" if not provided.
-	OutputFormat string
-	// Logger is used to log information acquired while processing the command.
-	Logger *logrus.Logger
-}
-
-// ListenAndReceive creates the Results channel and processes the results that
-// come through it before sending them on to `Print`. It is run in a separate
-// goroutine from `main`.
-func (ctx *Context) ListenAndReceive() {
-	ctx.Results = make(chan *Resource)
-	go func() {
-		for {
-			select {
-			case resource, ok := <-ctx.Results:
-
-				if !ok {
-					ctx.Results = nil
-					continue
-				}
-
-				if resource.Err != nil {
-
-					ctx.CLIContext.App.Writer = os.Stderr
-					resource.Keys = []string{"error"}
-					var errorBody string
-
-					switch resource.Err.(type) {
-
-					case *gophercloud.UnexpectedResponseCodeError:
-						errBodyRaw := resource.Err.(*gophercloud.UnexpectedResponseCodeError).Body
-						errMap := make(map[string]map[string]interface{})
-						err := json.Unmarshal(errBodyRaw, &errMap)
-						if err != nil {
-							errorBody = string(errBodyRaw)
-							break
-						}
-						for _, v := range errMap {
-							errorBody = v["message"].(string)
-							break
-						}
-
-					default:
-						errorBody = resource.Err.Error()
-					}
-
-					resource.Result = map[string]interface{}{"error": errorBody}
-				}
-
-				if resource.Result == nil {
-					if args := ctx.CLIContext.Parent().Parent().Args(); len(args) > 0 {
-						resource.Result = fmt.Sprintf("Nothing to show. Maybe you'd like to set up some %ss?\n",
-							strings.Replace(args[0], "-", " ", -1))
-					} else {
-						resource.Result = fmt.Sprintf("Nothing to show.\n")
-					}
-				}
-
-				ctx.Print(resource)
-				if resource.ErrExit1 {
-					os.Exit(1)
-				}
-			}
-		}
-	}()
-}
-
-// Print returns the output to the user
-func (ctx *Context) Print(resource *Resource) {
-	defer ctx.WaitGroup.Done()
-
-	// limit the returned fields if any were given in the `fields` flag
-	keys := ctx.limitFields(resource)
-	w := ctx.CLIContext.App.Writer
-
-	switch resource.Result.(type) {
-	case map[string]interface{}:
-		m := resource.Result.(map[string]interface{})
-		m = onlyNonNil(m)
-		switch ctx.OutputFormat {
-		case "json":
-			output.MetadataJSON(w, m, keys)
-		case "csv":
-			output.MetadataCSV(w, m, keys)
-		default:
-			output.MetadataTable(w, m, keys)
-		}
-	case []map[string]interface{}:
-		ms := resource.Result.([]map[string]interface{})
-		for i, m := range ms {
-			ms[i] = onlyNonNil(m)
-		}
-		switch ctx.OutputFormat {
-		case "json":
-			output.ListJSON(w, ms, keys)
-		case "csv":
-			output.ListCSV(w, ms, keys)
-		default:
-			output.ListTable(w, ms, keys)
-		}
-	case io.Reader:
-		if _, ok := resource.Result.(io.ReadCloser); ok {
-			defer resource.Result.(io.ReadCloser).Close()
-		}
-		_, err := io.Copy(w, resource.Result.(io.Reader))
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error copying (io.Reader) result: %s\n", err)
-		}
-	default:
-		switch ctx.OutputFormat {
-		case "json":
-			output.DefaultJSON(w, resource.Result)
-		default:
-			fmt.Fprintf(w, "%v", resource.Result)
-		}
-	}
+	outputFormat string
+	// logger is used to log information acquired while processing the command.
+	logger *logrus.Logger
 }
 
 func onlyNonNil(m map[string]interface{}) map[string]interface{} {
@@ -166,7 +49,7 @@ func onlyNonNil(m map[string]interface{}) map[string]interface{} {
 
 // limitFields returns only the fields the user specified in the `fields` flag. If
 // the flag wasn't provided, all fields are returned.
-func (ctx *Context) limitFields(resource *Resource) []string {
+func (ctx *Context) limitFields(resource *Resource) {
 	if ctx.CLIContext.IsSet("fields") {
 		fields := strings.Split(strings.ToLower(ctx.CLIContext.String("fields")), ",")
 		newKeys := []string{}
@@ -175,14 +58,13 @@ func (ctx *Context) limitFields(resource *Resource) []string {
 				newKeys = append(newKeys, key)
 			}
 		}
-		return newKeys
+		resource.Keys = newKeys
 	}
-	return resource.Keys
 }
 
 // StoreCredentials caches the users auth credentials if available and the `no-cache`
 // flag was not provided.
-func (ctx *Context) StoreCredentials() {
+func (ctx *Context) storeCredentials() {
 	// if serviceClient is nil, the HTTP request for the command didn't get sent.
 	// don't set cache if the `no-cache` flag is provided
 	if ctx.ServiceClient != nil && !ctx.CLIContext.GlobalIsSet("no-cache") && !ctx.CLIContext.IsSet("no-cache") {
@@ -221,7 +103,7 @@ func (ctx *Context) handleLogging() error {
 			return fmt.Errorf("Invalid value for `log` flag: %s. Valid options are: debug, info", opt)
 		}
 	}
-	ctx.Logger = &logrus.Logger{
+	ctx.logger = &logrus.Logger{
 		Out:       ctx.CLIContext.App.Writer,
 		Formatter: &logrus.TextFormatter{},
 		Level:     level,
@@ -229,12 +111,11 @@ func (ctx *Context) handleLogging() error {
 	return nil
 }
 
-// ErrExit1 tells `rack` to print the error and exit.
-func (ctx *Context) ErrExit1(resource *Resource) {
-	resource.ErrExit1 = true
-	ctx.WaitGroup.Add(1)
+// errExit1 tells `rack` to print the error and exit.
+func (ctx *Context) errExit1(resource *Resource) {
+	resource.errExit1 = true
 	ctx.Results <- resource
-	ctx.WaitGroup.Wait()
+	close(ctx.Results)
 }
 
 // IDOrName is a function for retrieving a resources unique identifier based on
@@ -262,7 +143,7 @@ func (ctx *Context) IDOrName(idFromNameFunc func(*gophercloud.ServiceClient, str
 func (ctx *Context) CheckArgNum(expected int) error {
 	argsLen := len(ctx.CLIContext.Args())
 	if argsLen != expected {
-		return fmt.Errorf("Expected %d args but got %d\nUsage: %s", expected, argsLen, ctx.CLIContext.Command.Usage)
+		return fmt.Errorf("Expected %d args but got %d\nUsage: %s\n", expected, argsLen, ctx.CLIContext.Command.Usage)
 	}
 	return nil
 }
@@ -283,7 +164,7 @@ func (ctx *Context) checkOutputFormat() error {
 	default:
 		return fmt.Errorf("Invalid value for `output` flag: '%s'. Options are: json, csv, table.", outputFormat)
 	}
-	ctx.OutputFormat = outputFormat
+	ctx.outputFormat = outputFormat
 	return nil
 }
 

--- a/handler/context.go
+++ b/handler/context.go
@@ -209,3 +209,17 @@ func (ctx *Context) CheckStructFlag(flagValues []string) ([]map[string]interface
 	}
 	return valSliceMap, nil
 }
+
+// HandleMetadata is used to flatten out a `map["metadata"]map[string]string`
+func (ctx *Context) HandleMetadata(resource *Resource) {
+	keys := resource.Keys
+	res := resource.Result.(map[string]interface{})
+	if metadata, ok := res["Metadata"]; ok && util.Contains(keys, "Metadata") {
+		for k, v := range metadata.(map[string]string) {
+			res[k] = v
+			keys = append(keys, k)
+		}
+	}
+	delete(res, "Metadata")
+	resource.Keys = util.RemoveFromList(keys, "Metadata")
+}

--- a/handler/handle.go
+++ b/handler/handle.go
@@ -2,11 +2,16 @@ package handler
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/jrperritt/rack/auth"
+	"github.com/jrperritt/rack/internal/github.com/rackspace/gophercloud"
+	"github.com/jrperritt/rack/output"
 )
 
 // Resource is a general resource from Rackspace. This object stores information
@@ -15,16 +20,14 @@ type Resource struct {
 	// Keys are the fields available to output. These may be limited by the `fields`
 	// flag.
 	Keys []string
-	// Print is a function for custom printing.
-	Print *func(*Resource)
 	// Params will be the command-specific parameters, such as an instance ID or
 	// list options.
 	Params interface{}
 	// Result will store the result of a single command.
 	Result interface{}
-	// ErrExit1 will be true if an error was encountered for which the program should
+	// errExit1 will be true if an error was encountered for which the program should
 	// exit.
-	ErrExit1 bool
+	errExit1 bool
 	// Err will store any error encountered while processing the command.
 	Err error
 }
@@ -54,6 +57,21 @@ type PipeHandler interface {
 	StdinField() string
 }
 
+// JSONer is an interface that commands will satisfy if they have a `JSON` method.
+type JSONer interface {
+	JSON(*Resource)
+}
+
+// CSVer is an interface that commands will satisfy if they have a `CSV` method.
+type CSVer interface {
+	CSV(*Resource)
+}
+
+// Tabler is an interface that commands will satisfy if they have a `Table` method.
+type Tabler interface {
+	Table(*Resource)
+}
+
 // Commander is an interface that all commands implement.
 type Commander interface {
 	// See `Context`.
@@ -74,9 +92,7 @@ type Commander interface {
 func Handle(command Commander) {
 	ctx := command.Context()
 	ctx.ServiceClientType = command.ServiceClientType()
-	ctx.WaitGroup = &sync.WaitGroup{}
-
-	ctx.ListenAndReceive()
+	ctx.Results = make(chan *Resource)
 
 	resource := &Resource{
 		Keys: command.Keys(),
@@ -85,35 +101,50 @@ func Handle(command Commander) {
 	err := ctx.CheckArgNum(0)
 	if err != nil {
 		resource.Err = err
-		ctx.ErrExit1(resource)
+		ctx.errExit1(resource)
 	}
 
 	err = ctx.checkOutputFormat()
 	if err != nil {
 		resource.Err = err
-		ctx.ErrExit1(resource)
+		ctx.errExit1(resource)
 	}
 
 	err = ctx.handleLogging()
 	if err != nil {
 		resource.Err = err
-		ctx.ErrExit1(resource)
+		ctx.errExit1(resource)
 	}
 
-	client, err := auth.NewClient(ctx.CLIContext, ctx.ServiceClientType, ctx.Logger)
+	client, err := auth.NewClient(ctx.CLIContext, ctx.ServiceClientType, ctx.logger)
 	if err != nil {
 		resource.Err = err
-		ctx.ErrExit1(resource)
+		ctx.errExit1(resource)
 	}
-	client.HTTPClient.Transport.(*auth.LogRoundTripper).Logger = ctx.Logger
+	client.HTTPClient.Transport.(*auth.LogRoundTripper).Logger = ctx.logger
 	ctx.ServiceClient = client
 
 	err = command.HandleFlags(resource)
 	if err != nil {
 		resource.Err = err
-		ctx.ErrExit1(resource)
+		ctx.errExit1(resource)
 	}
 
+	go handleExecute(command, resource)
+
+	for resource := range ctx.Results {
+		processResult(command, resource)
+		printResult(command, resource)
+		if resource.errExit1 {
+			os.Exit(1)
+		}
+	}
+
+	ctx.storeCredentials()
+}
+
+func handleExecute(command Commander, resource *Resource) {
+	ctx := command.Context()
 	// can the command accept input on STDIN?
 	if pipeableCommand, ok := command.(PipeHandler); ok {
 		// should we expect something on STDIN?
@@ -123,22 +154,22 @@ func Handle(command Commander) {
 			if stdinField == pipeableCommand.StdinField() {
 				// if so, does the given command and field accept streaming input?
 				if streamPipeableCommand, ok := pipeableCommand.(StreamPipeHandler); ok {
-					ctx.WaitGroup.Add(1)
 					go func() {
 						err := streamPipeableCommand.HandleStreamPipe(resource)
 						if err != nil {
 							resource.Err = fmt.Errorf("Error handling streamable, pipeable command: %s\n", err)
-							ctx.Results <- resource
 						} else {
 							streamPipeableCommand.Execute(resource)
-							ctx.Results <- resource
 						}
+						ctx.Results <- resource
+						close(ctx.Results)
 					}()
 				} else {
+					wg := sync.WaitGroup{}
 					scanner := bufio.NewScanner(os.Stdin)
 					for scanner.Scan() {
 						item := scanner.Text()
-						ctx.WaitGroup.Add(1)
+						wg.Add(1)
 						go func() {
 							err := pipeableCommand.HandlePipe(resource, item)
 							if err != nil {
@@ -148,36 +179,141 @@ func Handle(command Commander) {
 								pipeableCommand.Execute(resource)
 								ctx.Results <- resource
 							}
+							wg.Done()
 						}()
 					}
 					if scanner.Err() != nil {
 						resource.Err = scanner.Err()
-						ctx.ErrExit1(resource)
+						ctx.errExit1(resource)
 					}
+					wg.Wait()
+					close(ctx.Results)
 				}
 			} else {
 				resource.Err = fmt.Errorf("Unknown STDIN field: %s\n", stdinField)
-				ctx.ErrExit1(resource)
+				ctx.errExit1(resource)
 			}
 		} else {
-			ctx.WaitGroup.Add(1)
 			go func() {
 				err := pipeableCommand.HandleSingle(resource)
 				if err != nil {
 					resource.Err = err
-					ctx.ErrExit1(resource)
+					ctx.errExit1(resource)
 				}
 				command.Execute(resource)
 				ctx.Results <- resource
+				close(ctx.Results)
 			}()
 		}
 	} else {
-		ctx.WaitGroup.Add(1)
 		go func() {
 			command.Execute(resource)
 			ctx.Results <- resource
+			close(ctx.Results)
 		}()
 	}
-	ctx.WaitGroup.Wait()
-	ctx.StoreCredentials()
+}
+
+func processResult(command Commander, resource *Resource) {
+	ctx := command.Context()
+
+	// if an error was encountered during `handleExecution`, return it instead of
+	// the `resource.Result`.
+	if resource.Err != nil {
+		ctx.CLIContext.App.Writer = os.Stderr
+		resource.Keys = []string{"error"}
+		var errorBody string
+
+		switch resource.Err.(type) {
+		case *gophercloud.UnexpectedResponseCodeError:
+			errBodyRaw := resource.Err.(*gophercloud.UnexpectedResponseCodeError).Body
+			errMap := make(map[string]map[string]interface{})
+			err := json.Unmarshal(errBodyRaw, &errMap)
+			if err != nil {
+				errorBody = string(errBodyRaw)
+				break
+			}
+			for _, v := range errMap {
+				errorBody = v["message"].(string)
+				break
+			}
+		default:
+			errorBody = resource.Err.Error()
+		}
+
+		resource.Result = map[string]interface{}{"error": errorBody}
+	} else if resource.Result == nil {
+		if args := ctx.CLIContext.Parent().Parent().Args(); len(args) > 0 {
+			resource.Result = fmt.Sprintf("Nothing to show. Maybe you'd like to set up some %ss?\n",
+				strings.Replace(args[0], "-", " ", -1))
+		} else {
+			resource.Result = fmt.Sprintf("Nothing to show.\n")
+		}
+	} else {
+		// apply any output-specific transformations on the result
+		switch ctx.outputFormat {
+		case "json":
+			if jsoner, ok := command.(JSONer); ok {
+				jsoner.JSON(resource)
+			}
+		case "csv":
+			if csver, ok := command.(CSVer); ok {
+				csver.CSV(resource)
+			}
+		default:
+			if tabler, ok := command.(Tabler); ok {
+				tabler.Table(resource)
+			}
+		}
+
+		// limit the returned fields if any were given in the `fields` flag
+		ctx.limitFields(resource)
+	}
+}
+
+func printResult(command Commander, resource *Resource) {
+	ctx := command.Context()
+	w := ctx.CLIContext.App.Writer
+	keys := resource.Keys
+	switch resource.Result.(type) {
+	case map[string]interface{}:
+		m := resource.Result.(map[string]interface{})
+		m = onlyNonNil(m)
+		switch ctx.outputFormat {
+		case "json":
+			output.MetadataJSON(w, m, keys)
+		case "csv":
+			output.MetadataCSV(w, m, keys)
+		default:
+			output.MetadataTable(w, m, keys)
+		}
+	case []map[string]interface{}:
+		ms := resource.Result.([]map[string]interface{})
+		for i, m := range ms {
+			ms[i] = onlyNonNil(m)
+		}
+		switch ctx.outputFormat {
+		case "json":
+			output.ListJSON(w, ms, keys)
+		case "csv":
+			output.ListCSV(w, ms, keys)
+		default:
+			output.ListTable(w, ms, keys)
+		}
+	case io.Reader:
+		if _, ok := resource.Result.(io.ReadCloser); ok {
+			defer resource.Result.(io.ReadCloser).Close()
+		}
+		_, err := io.Copy(w, resource.Result.(io.Reader))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error copying (io.Reader) result: %s\n", err)
+		}
+	default:
+		switch ctx.outputFormat {
+		case "json":
+			output.DefaultJSON(w, resource.Result)
+		default:
+			fmt.Fprintf(w, "%v\n", resource.Result)
+		}
+	}
 }

--- a/handler/handle.go
+++ b/handler/handle.go
@@ -250,6 +250,9 @@ func processResult(command Commander, resource *Resource) {
 			resource.Result = fmt.Sprintf("Nothing to show.\n")
 		}
 	} else {
+		// limit the returned fields if any were given in the `fields` flag
+		ctx.limitFields(resource)
+
 		// apply any output-specific transformations on the result
 		switch ctx.outputFormat {
 		case "json":
@@ -265,9 +268,6 @@ func processResult(command Commander, resource *Resource) {
 				tabler.Table(resource)
 			}
 		}
-
-		// limit the returned fields if any were given in the `fields` flag
-		ctx.limitFields(resource)
 	}
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -22,6 +22,17 @@ func Usage(commandPrefix, action, mandatoryFlags string) string {
 	return fmt.Sprintf("%s [GLOBALS] %s %s %s [OPTIONS]", Name, commandPrefix, action, mandatoryFlags)
 }
 
+// RemoveFromList removes an element from a slice and returns the slice.
+func RemoveFromList(list []string, item string) []string {
+	for i, element := range list {
+		if element == item {
+			list = append(list[:i], list[i+1:]...)
+			break
+		}
+	}
+	return list
+}
+
 // Contains checks whether a given string is in a provided slice of strings.
 func Contains(s []string, e string) bool {
 	for _, a := range s {
@@ -44,6 +55,7 @@ func RackDir() (string, error) {
 	return dirpath, err
 }
 
+// HomeDir returns the user's home directory, which is platform-dependent.
 func HomeDir() (string, error) {
 	var homeDir string
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
This PR doesn't really add any important features, but it should make future development easier.

1. The `WaitGroup` field has been removed from the `Context` struct. We really only need `WaitGroup`s when we don't know how many goroutines we'll be spawning. Therefore, now the only logic with `WaitGroups` is in the block that handles piping to STDIN. In place of the `WaitGroup`s, there is a single `for`-loop that gets closed when there's nothing else to process.

2. The output functions can now be overridden by individual commands by implementing the `JSONer`, `CSVer`, and/or `Tabler` interfaces. If a command implements one of these interfaces, that method will be run before the result is processed. This is useful for commands that have different output for the different formats. For example, `keypair get` returns just the public key unless the user explicitly asks for JSON to be returned. As another example, when dealing with metadata, we'll likely want to return the actual items for tabular and CSV formats, but the `map[string]string` for JSON.