### PR TITLE
Add script to auto-generate man pages and add to travis bash script

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,9 +30,37 @@ OPTIONS:
 `
 	app := cli.NewApp()
 	app.Name = "rack"
-	app.Usage = "An opinionated CLI for the Rackspace cloud"
+	app.Usage = Usage()
 	app.EnableBashCompletion = true
-	app.Commands = []cli.Command{
+	app.Commands = Cmds()
+	app.Flags = util.GlobalFlags()
+	app.BashComplete = func(c *cli.Context) {
+		completeGlobals(globalOptions(app))
+	}
+	app.Before = func(c *cli.Context) error {
+		//fmt.Printf("c.Args: %+v\n", c.Args())
+		return nil
+	}
+	app.CommandNotFound = commandNotFound
+	app.Run(os.Args)
+}
+
+// Usage returns, you guessed it, the usage information
+func Usage() string {
+	return "An opinionated CLI for the Rackspace cloud"
+}
+
+// Desc returns, you guessed it, the description
+func Desc() string {
+	return `Rack is an opinionated command-line tool that allows Rackspace users 
+to accomplish tasks in a simple, idiomatic way. It seeks to provide
+flexibility through common Unix practices like piping and composability. All
+commands have been tested against Rackspace's live API.`
+}
+
+// Cmds returns a list of commands supported by the tool
+func Cmds() []cli.Command {
+	return []cli.Command{
 		{
 			Name:   "init",
 			Usage:  "[Linux/OS X only] Setup environment with command completion for the Bash shell.",
@@ -64,16 +92,6 @@ OPTIONS:
 			Subcommands: blockstoragecommands.Get(),
 		},
 	}
-	app.Flags = util.GlobalFlags()
-	app.BashComplete = func(c *cli.Context) {
-		completeGlobals(globalOptions(app))
-	}
-	app.Before = func(c *cli.Context) error {
-		//fmt.Printf("c.Args: %+v\n", c.Args())
-		return nil
-	}
-	app.CommandNotFound = commandNotFound
-	app.Run(os.Args)
 }
 
 // completeGlobals returns the options for completing global flags.

--- a/script/man.go
+++ b/script/man.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"time"
+
+	r "github.com/jrperritt/rack"
+	"github.com/jrperritt/rack/internal/github.com/codegangsta/cli"
+	"github.com/jrperritt/rack/util"
+)
+
+func main() {
+
+	content := fmt.Sprintln(`.\" Manpage for rack`)
+	content += fmt.Sprintln(`.\" Contact sdk-support@rackspace.com to correct errors or typos`)
+	content += fmt.Sprintf(`.TH man 1 "%s" "%s" "rack man page"`+"\n", time.Now().Format("06 May 2010"), util.Version)
+	content += fmt.Sprintln(`.SH NAME`)
+	content += fmt.Sprintf(`rack \- %s`+"\n", r.Usage())
+	content += fmt.Sprintln(`.SH SYNOPSIS`)
+	content += fmt.Sprintln("rack [GLOBALS] command subcommand [OPTIONS]")
+	content += fmt.Sprintln(`.SH DESCRIPTION`)
+	content += fmt.Sprintf("%s\n\n\n", r.Desc())
+
+	content += fmt.Sprintln("The following global options are available:")
+	for _, flag := range util.GlobalFlags() {
+		content += fmt.Sprintln(".TP")
+		name, usage := parseFlag(flag)
+		if name != "" && usage != "" {
+			content += fmt.Sprintf(`\fB\-\-%s\fR`+"\n", strings.Replace(name, "-", `\-`, -1))
+			content += fmt.Sprintln(usage)
+		} else {
+			content += fmt.Sprintln(flag.String())
+		}
+	}
+
+	content += fmt.Sprintln(`.SH TOP-LEVEL COMMANDS`)
+	for _, cmd := range r.Cmds() {
+		if len(cmd.Subcommands) > 0 {
+			continue
+		}
+		content += fmt.Sprintln(".TP")
+		content += fmt.Sprintf(`\fB%s\fR`+"\n", cmd.Name)
+		content += fmt.Sprintln(cmd.Usage)
+	}
+
+	for _, cmd := range r.Cmds() {
+		if len(cmd.Subcommands) == 0 {
+			continue
+		}
+		content += fmt.Sprintf(`.SH %s COMMANDS`+"\n", strings.ToUpper(cmd.Name))
+		content += fmt.Sprintln(cmd.Usage)
+		for _, serviceCmd := range cmd.Subcommands {
+			name := strings.ToUpper(serviceCmd.Name)
+			content += fmt.Sprintf(`.SS "\s-1%s COMMANDS\s0"`+"\n", name)
+			content += fmt.Sprintf(`.IX Subsection "%s"`+"\n", name)
+			for _, resourceCmd := range serviceCmd.Subcommands {
+				content += fmt.Sprintf(`.IP "\fB%s\fR"`+"\n", resourceCmd.Usage)
+				content += fmt.Sprintf(`.IX Item "%s"`+"\n", resourceCmd.Usage)
+				content += fmt.Sprintln(resourceCmd.Description)
+			}
+		}
+	}
+
+	content += fmt.Sprintln(".SH BUGS")
+	content += fmt.Sprintln("See https://github.com/jrperritt/rack/issues")
+
+	ioutil.WriteFile("rack.1", []byte(content), 0755)
+}
+
+func parseFlag(f cli.Flag) (string, string) {
+	name, usage := "", ""
+
+	if f, ok := f.(cli.StringFlag); ok {
+		name = f.Name
+		usage = f.Usage
+	}
+	if f, ok := f.(cli.BoolFlag); ok {
+		name = f.Name
+		usage = f.Usage
+	}
+	if f, ok := f.(cli.IntFlag); ok {
+		name = f.Name
+		usage = f.Usage
+	}
+
+	return name, usage
+}
+
+func flagUsage(f cli.Flag) string {
+	return ""
+}

--- a/script/prep-travis-release.sh
+++ b/script/prep-travis-release.sh
@@ -87,11 +87,16 @@ mkdir -p $BUILDDIR/$BASEDIR
 mkdir -p $BUILDDIR/$TREEDIR
 
 BASENAME="rack"
+MANFILE="rack.1"
 
 # Base build not in build dir to prevent accidental upload on failure
 RACKBUILD="${BASENAME}${SUFFIX}"
 
 go build -o $RACKBUILD
+
+# Generate man page
+go run script/man.go
+cp $MANFILE ${BUILDDIR}/${TREEDIR}/${BASENAME}-${BRANCH}".1"
 
 # Ship /tree/rack-branchname
 cp $RACKBUILD ${BUILDDIR}/${TREEDIR}/${BASENAME}-${BRANCH}${SUFFIX}
@@ -101,9 +106,11 @@ echo "${CDN}/${TREEDIR}/${BASENAME}-${BRANCH}${SUFFIX}"
 if [ "$BRANCH" == "master" ]; then
   # Only when we're on master do we spit out the official ones.
   cp $RACKBUILD ${BUILDDIR}/${BASEDIR}/${BASENAME}${SUFFIX}
+  cp $MANFILE ${BUILDDIR}/${BASEDIR}/${BASENAME}".1"
   echo "Get it while it's hot at"
   echo "${CDN}/${BASEDIR}/${BASENAME}${SUFFIX}"
 fi
 
 # Clean up after build
 rm $RACKBUILD
+rm $MANFILE


### PR DESCRIPTION
Addresses #163. For users who want man pages, they'll have to download them from the CDN (like the binary) and copy to a path of their choice. So:

```bash
wget https://cdn.rackspace.com/rack/rack.1
cp rack.1 /usr/local/share/man/man1
man rack
```

They can always just `man ./rack.1` too.