### PR TITLE
Better auth logic

### DIFF
--- a/handler/context.go
+++ b/handler/context.go
@@ -78,10 +78,10 @@ func (ctx *Context) storeCredentials() {
 			ServiceEndpoint: ctx.ServiceClient.Endpoint,
 		}
 		// get auth credentials
-		ao, region, err := auth.Credentials(ctx.CLIContext, nil)
+		credsResult, err := auth.Credentials(ctx.CLIContext, nil)
 		if err == nil {
 			// form the cache key
-			cacheKey := auth.CacheKey(*ao, region, ctx.ServiceClientType)
+			cacheKey := auth.CacheKey(*credsResult.AuthOpts, credsResult.Region, ctx.ServiceClientType)
 			// initialize the cache
 			cache := &auth.Cache{}
 			// set the cache value to the current values

--- a/setup/commandcompletion_bash.sh
+++ b/setup/commandcompletion_bash.sh
@@ -6,19 +6,19 @@ _cli_bash_autocomplete() {
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-  if [[ ${prev} != -* ]]; then
+  # The first 5 words should always be completed by rack
+  if [[ ${#COMP_WORDS[@]} -lt 5 ]]; then
     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
-    return 0
+  # All flags should be completed by rack
+  elif [[ ${cur} == -* ]]; then
+    opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+  # If the previous word wasn't a flag, then the next on has to be, given the 2 conditions above
+  elif [[ ${prev} != -* ]]; then
+    opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
   fi
-
-  if [[ "${#COMP_WORDS[@]}" > 4 ]] && [[ ${cur} != -* ]]; then
-    COMPREPLY=()
-    return 0
-  fi
-
-  opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
-  COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
   return 0
 }
 

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -22,19 +22,19 @@ _cli_bash_autocomplete() {
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-  if [[ ${prev} != -* ]]; then
+  # The first 5 words should always be completed by rack
+  if [[ ${#COMP_WORDS[@]} -lt 5 ]]; then
     opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
     COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
-    return 0
+  # All flags should be completed by rack
+  elif [[ ${cur} == -* ]]; then
+    opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+  # If the previous word wasn't a flag, then the next on has to be, given the 2 conditions above
+  elif [[ ${prev} != -* ]]; then
+    opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+    COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
   fi
-
-  if [[ "${#COMP_WORDS[@]}" > 4 ]] && [[ ${cur} != -* ]]; then
-    COMPREPLY=()
-    return 0
-  fi
-
-  opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
-  COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
   return 0
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -80,4 +80,4 @@ func Pluralize(noun string, count int64) string {
 
 // Version is the current CLI version
 var Version = "0.0.0-dev"
-var Commit = "f595fdf7f3eefc4be35f6ef7ac80d7ead7e47e7c"
+var Commit = "d69f4d2030b307076ad0a10f4b5addf440493aec"


### PR DESCRIPTION
This PR addresses 2 small but obvious problems:

1) In the bash completion, we're trying to get the length of the array and see if it's less than 4. But the `>` operator is doing string comparison, so it works until we get 10 or more words in the command. Then, since "10" (base 2) == 3, which is less than 4, we get unexpected behavior. Changing the operator to `-lt` fixes that.

2) Until now I've overlooked a possible auth scenario. It would be completely reasonable for a user to successfully authenticate with a username and API key (or a token and tenant ID), and then no longer provide the API key (or token), relying on the token from the cache. This PR adds logic to (hopefully) handle those situations.