### PR TITLE
global flag name change: tenant-id -> auth-tenant-id

### DIFF
--- a/auth/clients.go
+++ b/auth/clients.go
@@ -36,7 +36,7 @@ var tenantIDAuthErrSlice = []string{"There are some required Rackspace Cloud cre
 	"and here's what we're missing:",
 	"%s",
 	"",
-	"You can set the missing credentials with command-line flags (--auth-token, --tenant-id)",
+	"You can set the missing credentials with command-line flags (--auth-token, --auth-tenant-id)",
 	"",
 }
 
@@ -217,14 +217,14 @@ func Credentials(c *cli.Context, logger *logrus.Logger) (*CredentialsResult, err
 	delete(want, "region")
 
 	// now we check for token authentication (only allowed via the command-line)
-	want["tenant-id"] = ""
+	want["auth-tenant-id"] = ""
 	want["auth-token"] = ""
 	commandoptions.CLIopts(c, have, want)
 
 	// if a tenant ID was provided on the command-line, we don't bother checking for a
 	// username or api key
-	if have["tenant-id"].Value != "" || have["auth-token"].Value != "" {
-		if tenantID, ok := have["tenant-id"]; ok {
+	if have["auth-tenant-id"].Value != "" || have["auth-token"].Value != "" {
+		if tenantID, ok := have["auth-tenant-id"]; ok {
 			ao.TenantID = tenantID.Value
 			ao.TokenID = have["auth-token"].Value
 			delete(want, "auth-token")

--- a/commandoptions/globalflags.go
+++ b/commandoptions/globalflags.go
@@ -15,12 +15,12 @@ func GlobalFlags() []cli.Flag {
 			Usage: "The API key with which to authenticate.",
 		},
 		cli.StringFlag{
-			Name:  "tenant-id",
-			Usage: "The tenant ID of the user to authenticate as.",
+			Name:  "auth-tenant-id",
+			Usage: "The tenant ID of the user to authenticate as. May only be provided as a command-line flag.",
 		},
 		cli.StringFlag{
 			Name:  "auth-token",
-			Usage: "The authentication token of the user to authenticate as. This must be used with the `tenant-id` flag.",
+			Usage: "The authentication token of the user to authenticate as. This must be used with the `auth-tenant-id` flag.",
 		},
 		cli.StringFlag{
 			Name:  "auth-url",

--- a/docs/globaloptions.rst
+++ b/docs/globaloptions.rst
@@ -113,6 +113,18 @@ This presents a compact format with appropriate CSV headers.
 
   (string) The Rackspace API key to use for authentication.
 
+``--auth-tenant-id``
+~~~~~~~~~~~~~~~~~~~~
+
+  (string) The tenant ID to use for authentication. May only be provided as a command-line flag.
+  (Prefixed with 'auth-' so as to not collide with the `tenant-id` command flags.
+
+``--auth-token``
+~~~~~~~~~~~~~~~~
+
+  (string) The token to use for authentication. May only be provided as a command-line flag.
+  Must be used with the `auth-tenant-id` flag.
+
 ``--region``
 ~~~~~~~~~~~~
 
@@ -206,15 +218,6 @@ And again, per command:
        get		rack [globals] servers keypair get [--name <keypairName>] [flags]
        delete	rack servers keypair delete [--name <keypairName>] [flags]
        help, h	Shows a list of commands or help for one command
-
-``--version, -v``
-~~~~~~~~~~~~~~~~~
-
-  Print the version of the ``rack`` CLI.
-
-The version number of the CLI will be important when opening tickets, filing
-issues on the issue tracker or in any other debugging session. Please include
-this any time you are having issues.
 
 
 .. JSON: http://json.org/

--- a/util/util.go
+++ b/util/util.go
@@ -80,4 +80,4 @@ func Pluralize(noun string, count int64) string {
 
 // Version is the current CLI version
 var Version = "0.0.0-dev"
-var Commit = "d69f4d2030b307076ad0a10f4b5addf440493aec"
+var Commit = "07e635a690a073eed5969581794738170c6be90c"


### PR DESCRIPTION
There is a conflict with the global `tenant-id` used to authenticate and the `tenant-id` command flag that some commands allow. This PR renames the global flag to `auth-tenant-id`.