### PR TITLE
Cleaner way to build with commit hash

### DIFF
--- a/script/build
+++ b/script/build
@@ -3,7 +3,7 @@
 if [ -n "$GOPATH" ]; then
   echo "Building rack!"
   COMMIT=$(git rev-parse --verify HEAD)
-  sed -i "s/var Commit =.*/var Commit = \"$COMMIT\"/" util/util.go
+  echo -e "package util\n\nvar Commit = \"$COMMIT\"" > util/commit.go
   go build -o $GOPATH/bin/rack
 else
   echo '$GOPATH must be defined. Do you have go setup?'

--- a/util/commit.go
+++ b/util/commit.go
@@ -1,0 +1,3 @@
+package util
+
+var Commit = "07e635a690a073eed5969581794738170c6be90c"

--- a/util/util.go
+++ b/util/util.go
@@ -80,4 +80,3 @@ func Pluralize(noun string, count int64) string {
 
 // Version is the current CLI version
 var Version = "0.0.0-dev"
-var Commit = "07e635a690a073eed5969581794738170c6be90c"


### PR DESCRIPTION
This fixes some `sed` differences between Linux and OSX. Doesn't address compatibility on windows.